### PR TITLE
include <optional> header to fix compilation errors on gcc13

### DIFF
--- a/include/commata/typing_aid.hpp
+++ b/include/commata/typing_aid.hpp
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <string>
 #include <type_traits>
+#include <optional>
 
 namespace commata::detail {
 


### PR DESCRIPTION
Hi. Thank you for developing such a great library!

I met compilation error to build commata/0.2.7 on gcc13:
```
include/commata/typing_aid.hpp:38:39: error: ‘optional’ is not a member of ‘std’
   38 | constexpr bool is_std_optional_v<std::optional<T>> = true;
      |                                       ^~~~~~~~
include/commata/typing_aid.hpp:11:1: note: ‘std::optional’ is defined in header ‘<optional>’; did you forget to ‘#include <optional>’?
   10 | #include <iterator>
  +++ |+#include <optional>
   11 | #include <string>
include/commata/typing_aid.hpp:38:16: error: parse error in template argument list
   38 | constexpr bool is_std_optional_v<std::optional<T>> = true;
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/commata/typing_aid.hpp:38:49: error: expected initializer before ‘>’ token
   38 | constexpr bool is_std_optional_v<std::optional<T>> = true;
      |                                                 ^~
```

As gcc13 suggested, to include <optinal> seems to be required.
