### PR TITLE
Employ string_view literals to eradicate strlen-ing of string literals at run time

### DIFF
--- a/include/commata/detail/base_parser.hpp
+++ b/include/commata/detail/base_parser.hpp
@@ -6,6 +6,7 @@
 #ifndef COMMATA_GUARD_9AF7CB02_5702_4A95_AA5E_781F44203C7F
 #define COMMATA_GUARD_9AF7CB02_5702_4A95_AA5E_781F44203C7F
 
+#include <string_view>
 #include <type_traits>
 
 #include "handler_decorator.hpp"
@@ -255,11 +256,12 @@ private:
 
     std::pair<std::size_t, std::size_t> arrange_buffer_copy()
     {
+        using namespace std::string_literals;
         std::size_t buffer_size;
         std::tie(buffer_, buffer_size) = f_.get_buffer();   // throw
         if (buffer_size < 1) {
             throw std::out_of_range(
-                "Specified buffer length is shorter than one");
+                "Specified buffer length is shorter than one"s);
         }
 
         std::size_t loaded_size = 0;

--- a/include/commata/field_scanners.hpp
+++ b/include/commata/field_scanners.hpp
@@ -37,7 +37,8 @@ struct fail_if_skipped
     [[noreturn]]
     T operator()(T* = nullptr) const
     {
-        throw field_not_found("This field did not appear in this record");
+        using namespace std::string_view_literals;
+        throw field_not_found("This field did not appear in this record"sv);
     }
 };
 

--- a/include/commata/parse_csv.hpp
+++ b/include/commata/parse_csv.hpp
@@ -98,6 +98,7 @@ struct parse_step<state::in_value>
     void normal(Parser& parser, typename Parser::buffer_char_t*& p,
         typename Parser::buffer_char_t* pe) const
     {
+        using namespace std::string_view_literals;
         while (p < pe) {
             switch (*p) {
             case key_chars<typename Parser::char_type>::comma_c:
@@ -106,7 +107,7 @@ struct parse_step<state::in_value>
                 return;
             case key_chars<typename Parser::char_type>::dquote_c:
                 throw parse_error(
-                    "A quotation mark found in an unquoted value");
+                    "A quotation mark found in an unquoted value"sv);
             case key_chars<typename Parser::char_type>::cr_c:
                 parser.finalize();
                 parser.end_record();
@@ -161,7 +162,8 @@ struct parse_step<state::right_of_open_quote>
     template <class Parser>
     void eof(Parser& /*parser*/) const
     {
-        throw parse_error("EOF reached with an open quoted value");
+        using namespace std::string_view_literals;
+        throw parse_error("EOF reached with an open quoted value"sv);
     }
 };
 
@@ -205,7 +207,8 @@ struct parse_step<state::in_quoted_value>
     template <class Parser>
     void eof(Parser& /*parser*/) const
     {
-        throw parse_error("EOF reached with an open quoted value");
+        using namespace std::string_view_literals;
+        throw parse_error("EOF reached with an open quoted value"sv);
     }
 };
 
@@ -215,6 +218,7 @@ struct parse_step<state::in_quoted_value_after_quote>
     template <class Parser>
     void normal(Parser& parser, typename Parser::buffer_char_t* p, ...) const
     {
+        using namespace std::string_view_literals;
         switch (*p) {
         case key_chars<typename Parser::char_type>::comma_c:
             parser.finalize();
@@ -237,7 +241,7 @@ struct parse_step<state::in_quoted_value_after_quote>
             break;
         default:
             throw parse_error(
-                "An invalid character found after a closed quoted value");
+                "An invalid character found after a closed quoted value"sv);
         }
     }
 
@@ -290,7 +294,8 @@ struct parse_step<state::in_quoted_value_after_cr>
     template <class Parser>
     void eof(Parser& /*parser*/) const
     {
-        throw parse_error("EOF reached with an open quoted value");
+        using namespace std::string_view_literals;
+        throw parse_error("EOF reached with an open quoted value"sv);
     }
 };
 
@@ -331,7 +336,8 @@ struct parse_step<state::in_quoted_value_after_crs>
     template <class Parser>
     void eof(Parser& /*parser*/) const
     {
-        throw parse_error("EOF reached with an open quoted value");
+        using namespace std::string_view_literals;
+        throw parse_error("EOF reached with an open quoted value"sv);
     }
 };
 
@@ -373,7 +379,8 @@ struct parse_step<state::in_quoted_value_after_lf>
     template <class Parser>
     void eof(Parser& /*parser*/) const
     {
-        throw parse_error("EOF reached with an open quoted value");
+        using namespace std::string_view_literals;
+        throw parse_error("EOF reached with an open quoted value"sv);
     }
 };
 

--- a/include/commata/record_extractor.hpp
+++ b/include/commata/record_extractor.hpp
@@ -669,11 +669,12 @@ public:
 private:
     static std::size_t sanitize_target_field_index(std::size_t i)
     {
+        using namespace std::string_view_literals;
         if (i < record_extractor_npos) {
             return i;
         } else {
             std::ostringstream str;
-            str << "Target field index too large: " << i;
+            str << "Target field index too large: "sv << i;
             throw std::out_of_range(std::move(str).str());
         }
     }

--- a/include/commata/stored_table.hpp
+++ b/include/commata/stored_table.hpp
@@ -334,8 +334,9 @@ private:
     [[noreturn]]
     void throw_pos(size_type pos) const
     {
+        using namespace std::string_view_literals;
         std::ostringstream s;
-        s << pos << " is too large for this value, whose size is " << size();
+        s << pos << " is too large for this value, whose size is "sv << size();
         throw std::out_of_range(std::move(s).str());
     }
 };

--- a/include/commata/table_pull.hpp
+++ b/include/commata/table_pull.hpp
@@ -594,9 +594,10 @@ private:
         if (i < ds) {
             return access_impl(i);
         } else {
+            using namespace std::string_view_literals;
             std::ostringstream what;
-            what << "Too large suffix " << i
-                 << ": its maximum value is " << (ds - 1);
+            what << "Too large suffix "sv << i
+                 << ": its maximum value is "sv << (ds - 1);
             throw std::out_of_range(std::move(what).str());
         }
     }

--- a/src_test/TestCharInput.cpp
+++ b/src_test/TestCharInput.cpp
@@ -17,8 +17,8 @@
 
 #include "BaseTest.hpp"
 
-using namespace std::literals::string_literals;
-using namespace std::literals::string_view_literals;
+using namespace std::string_literals;
+using namespace std::string_view_literals;
 
 using namespace commata;
 using namespace commata::test;

--- a/src_test/TestParseCsv.cpp
+++ b/src_test/TestParseCsv.cpp
@@ -25,7 +25,7 @@
 #include "tracking_allocator.hpp"
 #include "simple_transcriptor.hpp"
 
-using namespace std::literals;
+using namespace std::string_view_literals;
 
 using namespace commata;
 using namespace commata::test;

--- a/src_test/TestRecordExtractor.cpp
+++ b/src_test/TestRecordExtractor.cpp
@@ -23,7 +23,8 @@
 #include "fancy_allocator.hpp"
 #include "tracking_allocator.hpp"
 
-using namespace std::literals;
+using namespace std::string_literals;
+using namespace std::string_view_literals;
 
 using namespace commata;
 using namespace commata::test;

--- a/src_test/TestTablePull.cpp
+++ b/src_test/TestTablePull.cpp
@@ -16,7 +16,7 @@
 
 #include "BaseTest.hpp"
 
-using namespace std::literals;
+using namespace std::string_view_literals;
 
 using namespace commata;
 using namespace commata::test;

--- a/src_test/TestTableScanner.cpp
+++ b/src_test/TestTableScanner.cpp
@@ -34,7 +34,7 @@
 #include "BaseTest.hpp"
 #include "tracking_allocator.hpp"
 
-using namespace std::literals;
+using namespace std::string_view_literals;
 using namespace commata;
 using namespace commata::test;
 

--- a/src_test/TestTextValueTranslation.cpp
+++ b/src_test/TestTextValueTranslation.cpp
@@ -25,7 +25,8 @@
 
 #include "BaseTest.hpp"
 
-using namespace std::literals;
+using namespace std::string_literals;
+using namespace std::string_view_literals;
 
 using namespace commata;
 using namespace commata::test;

--- a/src_test/simple_transcriptor.hpp
+++ b/src_test/simple_transcriptor.hpp
@@ -120,7 +120,8 @@ struct simple_transcriptor_with_nonconst_interface :
                       std::remove_const_t<Ch>* /*buffer_end*/)
     {
         if (!this->suppresses_buffer_events()) {
-            this->out() << "<<";
+            using namespace std::string_view_literals;
+            this->out() << "<<"sv;
         }
     }
 
@@ -128,21 +129,24 @@ struct simple_transcriptor_with_nonconst_interface :
     void end_buffer(std::remove_const_t<Ch>* /*buffer_last*/)
     {
         if (!this->suppresses_buffer_events()) {
-            this->out() << ">>";
+            using namespace std::string_view_literals;
+            this->out() << ">>"sv;
         }
     }
 
     using simple_transcriptor<Ch, Tr>::start_record;
     void start_record(std::remove_const_t<Ch>* /*record_begin*/)
     {
-        this->out() << "{{";
+        using namespace std::string_view_literals;
+        this->out() << "{{"sv;
     }
 
     using simple_transcriptor<Ch, Tr>::update;
     void update(std::remove_const_t<Ch>* first, std::remove_const_t<Ch>* last)
     {
         if (!this->is_in_value()) {
-            this->out() << "((";
+            using namespace std::string_view_literals;
+            this->out() << "(("sv;
             this->set_in_value(true);
         }
         this->out() << std::basic_string_view<std::remove_const_t<Ch>, Tr>(
@@ -153,8 +157,9 @@ struct simple_transcriptor_with_nonconst_interface :
     void finalize(std::remove_const_t<Ch>* first,
                   std::remove_const_t<Ch>* last)
     {
+        using namespace std::string_view_literals;
         this->update(first, last);
-        this->out() << "))";
+        this->out() << "))"sv;
         this->set_in_value(false);
         if constexpr (!std::is_const_v<Ch>) {
             *last = Ch();
@@ -164,7 +169,8 @@ struct simple_transcriptor_with_nonconst_interface :
     using simple_transcriptor<Ch, Tr>::end_record;
     void end_record(std::remove_const_t<Ch>* /*record_end*/)
     {
-        this->out() << "}}";
+        using namespace std::string_view_literals;
+        this->out() << "}}"sv;
     }
 
     using simple_transcriptor<Ch, Tr>::empty_physical_line;


### PR DESCRIPTION
Employ `std::string_view`'s literals so that terminating null characters should not be searched for at run time.

In addition, `using` directives for these literals are unified to `using std::string_view_literals;`