### PR TITLE
Make make_char_input(indirect, indirect, foo) equivalent to make_char_input(indirect, foo)

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2024-08-03 (UTC)</signature>
+<signature>2024-08-07 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -2807,11 +2807,11 @@ namespace commata {
   template &lt;class Ch, class Tr, class Allocator>
     [[nodiscard]] owned_string_input&lt;Ch, Tr, Allocator>
       make_char_input(std::basic_string&lt;Ch, Tr, Allocator>&amp;&amp; in) noexcept;
-  template &lt;class... Args>
-    [[nodiscard]] <nc>see below</nc> make_char_input(indirect_t, Args&amp;&amp;... args) noexcept(<nc>see below</nc>);
   template &lt;class Input>
     [[nodiscard]] indirect_input&lt;Input>
       make_char_input(indirect_t, indirect_input&lt;Input> input) noexcept(<nc>see below</nc>);
+  template &lt;class... Args>
+    [[nodiscard]] <nc>see below</nc> make_char_input(indirect_t, Args&amp;&amp;... args) noexcept(<nc>see below</nc>);
 }
       </codeblock>
 
@@ -3487,26 +3487,28 @@ template &lt;class Ch, class Tr, class Allocator>
 
       <code-item>
         <code>
-template &lt;class... Args>
-  [[nodiscard]] <nc>see below</nc> make_char_input(indirect_t, Args&amp;&amp;... args) noexcept(<nc>see below</nc>);
-        </code>
-        <effects><p>If <c>make_char_input(std::declval&lt;Args>()...)</c> is well-formed when treated as unevaluated operand, equivalent to:</p>
-                 <code>auto in = make_char_input(std::forward&lt;Args>(args)...);
-return indirect_input&lt;decltype(in)>(std::move(in));
-</code>
-                 <p>Otherwise, equivalent to: <c>return indirect_input&lt;Args...>(std::forward&lt;Args>(args)...);</c></p></effects>
-        <remark>This overload shall not participate in overload resolution unless the first type in <c>std::decay_t&lt;Args>...</c> (if any) is not identical to or not derived from <c>indirect_t</c>, and either <c>make_char_input(std::declval&lt;Args>()...)</c> is well-formed when treated as unevaluated operand or <c>sizeof...(Args)</c> is equal to <c>1</c>.
-                The expression inside <c>noexcept</c> is <c>true</c> unless the equivalent expressions described above is potentially-throwing.</remark>
-      </code-item>
-
-      <code-item>
-        <code>
 template &lt;class Input>
   [[nodiscard]] indirect_input&lt;Input>
     make_char_input(indirect_t, indirect_input&lt;Input> input) noexcept(<nc>see below</nc>);
         </code>
         <returns><c>indirect_input&lt;Input>(std::move(input.base()))</c>.</returns>
         <remark>The expression inside <c>noexcept</c> is equivalent to <c>std::is_nothrow_move_constructible_v&lt;Input></c>.</remark>
+      </code-item>
+
+      <code-item>
+        <code>
+template &lt;class... Args>
+  [[nodiscard]] <nc>see below</nc> make_char_input(indirect_t, Args&amp;&amp;... args) noexcept(<nc>see below</nc>);
+        </code>
+        <effects><p>Let <c>Ts</c> be a pack obtained by dropping the first consecutive members from <c>Args...</c> each of which is a possibly cv-qualified and possibly reference-added type of <c>indirect_t</c>,
+                    and let <c>ts</c> be a pack obtained by dropping the first members from <c>args...</c> corresponding to the members in <c>Args...</c> dropped to obtain <c>Ts</c>.
+                    Then if <c>make_char_input(std::declval&lt;Ts>()...)</c> is well-formed when treated as unevaluated operand, equivalent to:</p>
+                 <code>auto in = make_char_input(std::forward&lt;Ts>(ts)...);
+return indirect_input&lt;decltype(in)>(std::move(in));
+</code>
+                 <p>Otherwise, equivalent to: <c>return indirect_input&lt;Args...>(std::forward&lt;Args>(args)...);</c></p></effects>
+        <remark>This overload shall not participate in overload resolution unless the first type in <c>std::decay_t&lt;Args>...</c> (if any) is not identical to or not derived from <c>indirect_t</c>, and either <c>make_char_input(std::declval&lt;Args>()...)</c> is well-formed when treated as unevaluated operand or <c>sizeof...(Args)</c> is equal to <c>1</c>.
+                The expression inside <c>noexcept</c> is <c>true</c> unless the equivalent expressions described above is potentially-throwing.</remark>
       </code-item>
     </section>
   </section>

--- a/src_test/TestCharInput.cpp
+++ b/src_test/TestCharInput.cpp
@@ -615,6 +615,15 @@ static_assert(
 static_assert(std::is_same_v<is_t,
     decltype(make_char_input(indirect, std::declval<is_t>()))>);
 
+static_assert(std::is_same_v<io_t,
+    decltype(make_char_input(indirect, indirect, "ABC"s))>);
+
+static_assert(std::is_same_v<is_t,
+    decltype(make_char_input(indirect, indirect, indirect, "ABC"sv))>);
+
+static_assert(std::is_same_v<is_t,
+    decltype(make_char_input(indirect, std::declval<is_t>()))>);
+
 }
 
 }


### PR DESCRIPTION
On a5a9c8e98c5f431239fc3dd5a061371ed235c891, I stated:

> I think make_char_input(indirect, indirect, "ABC") should be equivalent to make_char_input(indirect, "ABC") rather than causing a compilation error, but at this time this is the limit of my efforts

But I found that this is not so difficult and can be achieved with not-that-many diffs. This pull request is to do so.

Strictly speaking, this might not be a bug fix. But this is not likely to cause compatibility issues, nor introducing 'new' features, so I would like to include this diffs to the next bug fix release.