### PR TITLE
Add COMMATA_ENABLE_FULL_EBO flag to enforce EBO even for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(commata INTERFACE
     include/commata/detail/buffer_control.hpp
     include/commata/detail/buffer_size.hpp
     include/commata/detail/formatted_output.hpp
+    include/commata/detail/full_ebo.hpp
     include/commata/detail/handler_decorator.hpp
     include/commata/detail/key_chars.hpp
     include/commata/detail/member_like_base.hpp

--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2024-08-07 (UTC)</signature>
+<signature>2024-08-19 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -25,17 +25,43 @@
   <section id="introduction.using">
     <name>Using Commata</name>
 
-    <p>A translation unit may include headers described in this document in any order.
-       Each may be included more than once, with no effect different from being included exactly once.</p>
-    <p>A translation unit shall include a header described in this document only outside of any external declaration or definition, and shall include the header lexically before the first reference in that translation unit to any of the entities declared in that header.</p>
-    <p>A translation unit shall not define a macro whose name meets one of the following before a point of an <c>#include</c> preprocessor directive that includes a header described in this document:</p>
-    <ul>
-      <li>it consists only of one uppercase alphabetic letter,</li>
-      <li>it begins with a lowercase alphabetic letter,</li>
-      <li>it consists only of alphabetic letters and possibly zero decimal digit characters, and contains both of an uppercase alphabetic letter and a lowercase one, or</li>
-      <li>it begins with <c>COMMATA_</c>.</li>
-    </ul>
-    <p>Headers described in this document may define macros whose name begin with <c>COMMATA_</c> and may not define any macros with other names.</p>
+    <section id="introduction.using.general">
+      <name>General</name>
+      <p>A translation unit may include headers described in this document in any order.
+        Each may be included more than once, with no effect different from being included exactly once.</p>
+      <p>A translation unit shall include a header described in this document only outside of any external declaration or definition, and shall include the header lexically before the first reference in that translation unit to any of the entities declared in that header.</p>
+      <p>A translation unit shall not define a macro whose name meets one of the following before a point of an <c>#include</c> preprocessor directive that includes a header described in this document:</p>
+      <ul>
+        <li>it consists only of one uppercase alphabetic letter,</li>
+        <li>it begins with a lowercase alphabetic letter,</li>
+        <li>it consists only of alphabetic letters and possibly zero decimal digit characters, and contains both of an uppercase alphabetic letter and a lowercase one, or</li>
+        <li>it begins with <c>COMMATA_</c> and is not identical to any of macros described in <xref id="macros"/>.</li>
+      </ul>
+      <p>Headers described in this document may define macros whose name begin with <c>COMMATA_</c> and may not define any macros with other names.</p>
+    </section>
+
+    <section id="macros">
+      <name>Macros controlling Commata</name>
+      <p>Commata offers macros that control the functionality of Commata as described in <xref id="table.macros"/>.
+         When these macros are defined, they shall be defined throughout all of Commata headers in any translation units forming the program.</p>
+      <table id="table.macros">
+        <caption>Macros controlling Commata</caption>
+        <col width="1"/><col width="6"/><col width="21"/>
+
+        <tr>
+          <th>#</th>
+          <th>Macro</th>
+          <th>Remarks</th>
+        </tr>
+
+        <tr>
+          <td>(1)</td>
+          <td><c>COMMATA_ENABLE_FULL_EBO</c></td>
+          <td>When specified, Commata strives to achieve the maximum level of so-called empty base optimization,
+              which is a technique to minimize sizes of class types with deriving from empty classes instead of having members of those types.</td>
+        </tr>
+      </table>
+    </section>
   </section>
 
   <section id="concepts">

--- a/include/commata/detail/buffer_control.hpp
+++ b/include/commata/detail/buffer_control.hpp
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "buffer_size.hpp"
+#include "full_ebo.hpp"
 #include "handler_decorator.hpp"
 #include "member_like_base.hpp"
 
@@ -103,7 +104,7 @@ constexpr bool is_full_fledged_v =
 // exception in its interface because it may be good for implementation of
 // optimized parsers to take advantage of their absence
 template <class Handler, class BufferControl>
-class full_fledged_handler :
+class COMMATA_FULL_EBO full_fledged_handler :
     BufferControl,
     public handler_core_t<Handler,
                           full_fledged_handler<Handler, BufferControl>>,

--- a/include/commata/detail/full_ebo.hpp
+++ b/include/commata/detail/full_ebo.hpp
@@ -1,0 +1,16 @@
+/**
+ * These codes are licensed under the Unlicense.
+ * http://unlicense.org
+ */
+
+#ifndef COMMATA_GUARD_FDC314CE_0C3D_47F8_AD9E_EF60154FAB89
+#define COMMATA_GUARD_FDC314CE_0C3D_47F8_AD9E_EF60154FAB89
+
+#if defined(COMMATA_ENABLE_FULL_EBO) \
+ && defined(_MSC_VER) && _MSC_FULL_VER >= 190024210
+#define COMMATA_FULL_EBO __declspec(empty_bases)
+#else
+#define COMMATA_FULL_EBO
+#endif
+
+#endif

--- a/include/commata/detail/handler_decorator.hpp
+++ b/include/commata/detail/handler_decorator.hpp
@@ -11,6 +11,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "full_ebo.hpp"
+
 namespace commata::detail {
 
 namespace handler_decoration {
@@ -342,7 +344,7 @@ struct handler_core_t
 // to base()'s member functions with corresponding names; it does not expose
 // any excess member functions that Handler does not expose
 template <class Handler, class D>
-struct handler_decorator :
+struct COMMATA_FULL_EBO handler_decorator :
     get_buffer_t<Handler, D>, release_buffer_t<Handler, D>,
     start_buffer_t<Handler, D>, end_buffer_t<Handler, D>,
     empty_physical_line_t<Handler, D>, handler_core_t<Handler, D>,

--- a/include/commata/field_scanners.hpp
+++ b/include/commata/field_scanners.hpp
@@ -19,6 +19,7 @@
 
 #include "text_error.hpp"
 #include "text_value_translation.hpp"
+#include "detail/full_ebo.hpp"
 
 namespace commata {
 
@@ -708,7 +709,7 @@ public:
 };
 
 template <class Container, class SkippingHandler = fail_if_skipped>
-class string_field_inserter :
+class COMMATA_FULL_EBO string_field_inserter :
     detail::member_like_base<SkippingHandler>,
     detail::member_like_base<typename Container::value_type::allocator_type>
 {

--- a/include/commata/stored_table.hpp
+++ b/include/commata/stored_table.hpp
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "detail/buffer_size.hpp"
+#include "detail/full_ebo.hpp"
 #include "detail/member_like_base.hpp"
 #include "detail/propagation_controlled_allocator.hpp"
 #include "detail/string_value.hpp"
@@ -2075,7 +2076,7 @@ struct end_record_handler
 };
 
 template <class StoredTable, class T>
-struct typed_end_record_handler :
+struct COMMATA_FULL_EBO typed_end_record_handler :
     end_record_handler<StoredTable>, private detail::member_like_base<T>
 {
     template <class U>

--- a/include/commata/table_scanner.hpp
+++ b/include/commata/table_scanner.hpp
@@ -20,6 +20,7 @@
 
 #include "detail/allocation_only_allocator.hpp"
 #include "detail/buffer_size.hpp"
+#include "detail/full_ebo.hpp"
 #include "detail/member_like_base.hpp"
 #include "detail/typing_aid.hpp"
 
@@ -96,7 +97,7 @@ class basic_table_scanner
     };
 
     template <class HeaderScanner>
-    class typed_header_field_scanner :
+    class COMMATA_FULL_EBO typed_header_field_scanner :
         public header_field_scanner, detail::member_like_base<HeaderScanner>
     {
         static constexpr bool const_ready = std::is_invocable_v<HeaderScanner&,
@@ -170,13 +171,14 @@ class basic_table_scanner
         }
     };
 
-    struct body_field_scanner : field_scanner, detail::scanner::typable
+    struct COMMATA_FULL_EBO body_field_scanner :
+        field_scanner, detail::scanner::typable
     {
         virtual void field_skipped() = 0;
     };
 
     template <class FieldScanner>
-    struct typed_body_field_scanner :
+    struct COMMATA_FULL_EBO typed_body_field_scanner :
         body_field_scanner, private detail::member_like_base<FieldScanner>
     {
         template <class T>
@@ -265,7 +267,7 @@ class basic_table_scanner
     };
 
     template <class T>
-    struct typed_record_end_scanner :
+    struct COMMATA_FULL_EBO typed_record_end_scanner :
         record_end_scanner, private detail::member_like_base<T>
     {
         template <class U>

--- a/src_test/CMakeLists.txt
+++ b/src_test/CMakeLists.txt
@@ -66,6 +66,7 @@ source_group(TREE ${COMMATA_HEADERS_ROOT}
              FILES ${COMMATA_HEADERS})
 
 target_compile_features(test_commata PRIVATE cxx_std_17)
+add_compile_definitions(COMMATA_ENABLE_FULL_EBO)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(test_commata PRIVATE


### PR DESCRIPTION
Microsoft [says](https://learn.microsoft.com/en-us/cpp/cpp/empty-bases?view=msvc-170) that Microsoft Visual Studio has limited capability of empty base optimization (EBO) by default. I have not known that.

It seems easy to turn full EBO on, but it breaks ABI compatibility, that is, it can make older object files and newer object files not link. This time it seems better to leave turning full EBO optional on. So, this pull request offers full EBO with `COMMATA_ENABLE_FULL_EBO` macro as its switch.

From now on, the tests are going to be built with `COMMATA_ENABLE_FULL_EBO` defined because the ABI compatibility should not matter the tests.