### PR TITLE
Re-adjust column widths of the table on replace_if_skipped::operator()

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -7072,7 +7072,7 @@ template &lt;class U = T> std::optional&lt;U> operator()(U* = nullptr) const;
 
             <table id="table.replace_if_skipped.skipped">
               <caption>Effects of calling of <c>operator()</c></caption>
-              <col width="13"/><col width="5"/><col width="18"/>
+              <col width="2"/><col width="5"/><col width="29"/>
 
               <tr>
                 <th>#</th>


### PR DESCRIPTION
The spec has had an unnatural layout on a table on`replace_if_skipped::operator()`.

This has originally resulted from unifying the layout with the table on `replace_if_conversion_failed::operator()`, but now `replace_if_skipped` and `replace_if_conversion_failed` are located far apart in the spec, so this kind of layout-unifying seems no use.