### PR TITLE
Make basic_stored_table::shrink_to_fit preserve its allocator

### DIFF
--- a/include/commata/stored_table.hpp
+++ b/include/commata/stored_table.hpp
@@ -1545,7 +1545,8 @@ public:
 
     void shrink_to_fit()
     {
-        basic_stored_table(*this).swap(*this);     // throw
+        basic_stored_table(std::allocator_arg, get_allocator(), *this)
+            .swap(*this);   // throw
     }
 
     void swap(basic_stored_table& other)


### PR DESCRIPTION
even if its allocator's `select_on_container_copy_construction` returns another allocator because no users will expect that the allocator is replaced after `shrink_to_fit` with a different allocator returned by `select_on_container_copy_construction`.