### PR TITLE
Take care of a rather fatal bug of string_field_inserter

### DIFF
--- a/include/commata/field_scanners.hpp
+++ b/include/commata/field_scanners.hpp
@@ -856,7 +856,8 @@ private:
          && std::is_invocable_r_v<bool, Comp, string_type, value_type>,
             std::void_t<typename Comp::is_transparent>>
     {
-        if (const auto i = c.lower_bound(v); (i == c.end()) || (v < *i)) {
+        if (const auto i = c.lower_bound(v);
+                (i == c.end()) || c.key_comp()(v, *i)) {
             c.emplace_hint(i, v, get_allocator());
         }
     }

--- a/src_test/TestTableScanner.cpp
+++ b/src_test/TestTableScanner.cpp
@@ -184,7 +184,7 @@ TYPED_TEST(TestFieldTranslatorForStringTypes, StringFieldInserterUniqSet)
     const auto str = char_helper<char_t>::str;
 
     std::set<string_t, std::less<>> values1;
-    std::set<string_t, std::less<>> values2;
+    std::set<string_t, std::greater<>> values2;
 
     basic_table_scanner<char_t> scanner;
 


### PR DESCRIPTION
which mistakingly employed an operator less-than in place of `key_comp()`.
