### PR TITLE
Make HeaderFieldScanner-taking ctors of basic_table_scanner widely SFINAEd out

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2024-12-12 (UTC)</signature>
+<signature>2024-12-19 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -6599,10 +6599,10 @@ template &lt;class HeaderFieldScanner>
           </code>
           <preface>Let <c>T</c> be <c>std::decay_t&lt;HeaderFieldScanner></c>.</preface>
           <requires><c>T</c> shall meet the <c>HeaderFieldScanner</c> requirements (<xref id="header_field_scanner.requirements"/>) for <c>basic_table_scanner&lt;Ch, Tr, Allocator></c>.</requires>
-          <effects>Constructs an object of <c>basic_table_scanner</c> with an header field scanner object installed.
+          <effects>Constructs an object of <c>basic_table_scanner</c> with a header field scanner object installed.
                    The scanner shall allocate and deallocate memory with a default constructed <c>Allocator</c> object (first form) or a copy of <c>alloc</c> (second form).</effects>
           <postcondition><c>*this</c> has a header field scanner object installed whose type is <c>T</c> and that is constructed with <c>std::forward&lt;HeaderFieldScanner>(s)</c>, and no body field scanners installed.</postcondition>
-          <remark>These constructors shall not participate in overload resolution unless <c>std::is_integral_v&lt;T></c> is <c>false</c>.</remark>
+          <remark>These constructors shall not participate in overload resolution unless <c>std::is_arithmetic_v&lt;T></c> is <c>false</c>.</remark>
         </code-item>
       </section>
 

--- a/include/commata/table_scanner.hpp
+++ b/include/commata/table_scanner.hpp
@@ -339,7 +339,7 @@ public:
     {}
 
     template <class HeaderFieldScanner,
-        std::enable_if_t<!std::is_integral_v<HeaderFieldScanner>>* = nullptr>
+        std::enable_if_t<!std::is_arithmetic_v<HeaderFieldScanner>>* = nullptr>
     explicit basic_table_scanner(HeaderFieldScanner&& s) :
         basic_table_scanner(
             std::allocator_arg, Allocator(),
@@ -363,8 +363,8 @@ public:
     {}
 
     template <class HeaderFieldScanner,
-        std::enable_if_t<
-            !std::is_integral_v<std::decay_t<HeaderFieldScanner>>>* = nullptr>
+        std::enable_if_t<!std::is_arithmetic_v<
+            std::decay_t<HeaderFieldScanner>>>* = nullptr>
     basic_table_scanner(
         std::allocator_arg_t, const Allocator& alloc, HeaderFieldScanner&& s) :
         buffer_(), begin_(nullptr), value_(alloc),


### PR DESCRIPTION
`basic_table_scanner` has two groups of constructors: one takes a header record count, and another takes a HeaderFieldScanner object. The latter was SFINAEd out when the type is not an integral type.

But also a floating point object cannot behave as a HeaderFieldScanner,  so integal-ness does not seem to be the point. This pull request widens the condition of HeaderFieldScanner-taking ctor SFINAEd out so that floating point types should not be treated as HeadeFieldScanner types.

This change seems not to affect existing valid codes.
