### PR TITLE
Reduce visibility of some members of base_source

### DIFF
--- a/include/commata/detail/base_source.hpp
+++ b/include/commata/detail/base_source.hpp
@@ -28,6 +28,7 @@ public:
     using char_type = typename CharInput::char_type;
     using traits_type = typename CharInput::traits_type;
 
+protected:
     explicit base_source(const CharInput& input) noexcept(
             std::is_nothrow_copy_constructible_v<CharInput>) :
         in_(input)
@@ -216,8 +217,11 @@ public:
                                 std::forward<Args>(args)...);
     }
 
-    void swap(base_source& other)
-        noexcept(std::is_nothrow_swappable_v<CharInput>)
+protected:
+    static constexpr bool swap_noexcept =
+        std::is_nothrow_swappable_v<CharInput>;
+
+    void swap(base_source& other) noexcept(swap_noexcept)
     {
         if (this != std::addressof(other)) {
             using std::swap;

--- a/include/commata/parse_csv.hpp
+++ b/include/commata/parse_csv.hpp
@@ -588,7 +588,7 @@ public:
     csv_source& operator=(const csv_source&) = default;
     csv_source& operator=(csv_source&&) = default;
 
-    void swap(csv_source& other) noexcept(std::is_nothrow_swappable_v<base_t>)
+    void swap(csv_source& other) noexcept(base_t::swap_noexcept)
     {
         base_t::swap(other);
     }

--- a/include/commata/parse_tsv.hpp
+++ b/include/commata/parse_tsv.hpp
@@ -299,7 +299,7 @@ public:
     tsv_source& operator=(const tsv_source&) = default;
     tsv_source& operator=(tsv_source&&) = default;
 
-    void swap(tsv_source& other) noexcept(std::is_nothrow_swappable_v<base_t>)
+    void swap(tsv_source& other) noexcept(base_t::swap_noexcept)
     {
         base_t::swap(other);
     }


### PR DESCRIPTION
Literally. This pull request is to reduce visibility of some members of `base_source`, which is the base class of `csv_source` and `tsv_source`. The members are ctors, dtor, assignment ops,  and `swap`.