### PR TITLE
Make parse_(c|t)sv cast the return value of the parser

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2025-01-25 (UTC)</signature>
+<signature>2025-02-06 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -3816,7 +3816,7 @@ template &lt;class CharInputR>
 template &lt;class CharInput, class... OtherArgs>
   bool parse_csv(const csv_source&lt;CharInput>&amp;  src, OtherArgs&amp;&amp;... other_args);
         </code>
-        <effects>Equivalent to: <c>return src(std::forward&lt;OtherArgs>(other_args)...)();</c>.</effects>
+        <effects>Equivalent to: <c>return static_cast&lt;bool>(src(std::forward&lt;OtherArgs>(other_args)...)());</c>.</effects>
       </code-item>
 
       <code-item>
@@ -3824,7 +3824,7 @@ template &lt;class CharInput, class... OtherArgs>
 template &lt;class CharInput, class... OtherArgs>
   bool parse_csv(      csv_source&lt;CharInput>&amp;&amp; src, OtherArgs&amp;&amp;... other_args);
         </code>
-        <effects>Equivalent to: <c>return std::move(src)(std::forward&lt;OtherArgs>(other_args)...)();</c>.</effects>
+        <effects>Equivalent to: <c>return static_cast&lt;bool>(std::move(src)(std::forward&lt;OtherArgs>(other_args)...)());</c>.</effects>
       </code-item>
 
       <code-item>
@@ -4137,7 +4137,7 @@ template &lt;class CharInputR>
 template &lt;class CharInput, class... OtherArgs>
   bool parse_tsv(const tsv_source&lt;CharInput>&amp;  src, OtherArgs&amp;&amp;... other_args);
         </code>
-        <effects>Equivalent to: <c>return src(std::forward&lt;OtherArgs>(other_args)...)();</c>.</effects>
+        <effects>Equivalent to: <c>return static_cast&lt;bool>(src(std::forward&lt;OtherArgs>(other_args)...)());</c>.</effects>
       </code-item>
 
       <code-item>
@@ -4145,7 +4145,7 @@ template &lt;class CharInput, class... OtherArgs>
 template &lt;class CharInput, class... OtherArgs>
   bool parse_tsv(      tsv_source&lt;CharInput>&amp;&amp; src, OtherArgs&amp;&amp;... other_args);
         </code>
-        <effects>Equivalent to: <c>return std::move(src)(std::forward&lt;OtherArgs>(other_args)...)();</c>.</effects>
+        <effects>Equivalent to: <c>return static_cast&lt;bool>(std::move(src)(std::forward&lt;OtherArgs>(other_args)...)());</c>.</effects>
       </code-item>
 
       <code-item>

--- a/include/commata/parse_csv.hpp
+++ b/include/commata/parse_csv.hpp
@@ -668,13 +668,14 @@ constexpr bool is_indirect_t_v<indirect_t> = true;
 template <class CharInput, class... OtherArgs>
 bool parse_csv(const csv_source<CharInput>& src, OtherArgs&&... other_args)
 {
-    return src(std::forward<OtherArgs>(other_args)...)();
+    return static_cast<bool>(src(std::forward<OtherArgs>(other_args)...)());
 }
 
 template <class CharInput, class... OtherArgs>
 bool parse_csv(csv_source<CharInput>&& src, OtherArgs&&... other_args)
 {
-    return std::move(src)(std::forward<OtherArgs>(other_args)...)();
+    return static_cast<bool>(
+        std::move(src)(std::forward<OtherArgs>(other_args)...)());
 }
 
 template <class Arg1, class Arg2, class... OtherArgs>

--- a/include/commata/parse_tsv.hpp
+++ b/include/commata/parse_tsv.hpp
@@ -379,13 +379,14 @@ constexpr bool is_indirect_t_v<indirect_t> = true;
 template <class CharInput, class... OtherArgs>
 bool parse_tsv(const tsv_source<CharInput>& src, OtherArgs&&... other_args)
 {
-    return src(std::forward<OtherArgs>(other_args)...)();
+    return static_cast<bool>(src(std::forward<OtherArgs>(other_args)...)());
 }
 
 template <class CharInput, class... OtherArgs>
 bool parse_tsv(tsv_source<CharInput>&& src, OtherArgs&&... other_args)
 {
-    return std::move(src)(std::forward<OtherArgs>(other_args)...)();
+    return static_cast<bool>(
+        std::move(src)(std::forward<OtherArgs>(other_args)...)());
 }
 
 template <class Arg1, class Arg2, class... OtherArgs>


### PR DESCRIPTION
The spec only mandates that the return type of a `TextParser`'s invocation shall be 'contextually convertible to `bool`'. So, it is inappropriate for `parse_csv` or `parse_tsv` to return a raw return value of its parser as a `bool`.

This situation can be solved with specifying that the parser types of `csv_source` and `tsv_source` shall have  `bool` as the return type of their invocation. But I would think it could be ugly and pointlessly too restrictive. So, by this pull request, I would like to explicitly cast the return value of the parsers to `bool`.

The primer says:

> More technically (but still roughly speaking), `parse_csv(foo, bar)` is a shorthand for `make_csv_source(foo)(bar)()`.

but I would think this notion does not need to be updated because it accompanies a caveat with 'still roughly speaking'.