### PR TITLE
Improve parsers' spec and implementation on parse errors

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2025-01-25 (UTC)</signature>
+<signature>2025-02-05 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -346,7 +346,8 @@
           <td>Retrieves the text content from its tied character source object, parses the text content, and calls the member functions of its tied table handler object compliantly with the <c>TableHandler</c> requirements.
               Returns <c>false</c> if the return value of a call on <c>empty_physical_line</c>, <c>start_record</c>, <c>end_record</c>, <c>update</c>, or <c>finalize</c> is <c>false</c>; <c>true</c> otherwise.
               Throws an object of <c>parse_error</c> (<xref id="parse_error"/>) or its derived type if the text content cannot be parsed into a text table (<xref id="definitions.text_table"/>).
-              <span class="note">Implementations are free to exit via an exception on erroneous situations other than this.</span>
+              <span class="note">Implementations are free to exit via an exception on erroneous situations other than this.
+                                 To be specific, implementations need not have so-called exception-neutral nature.</span>
               If this returns <c>false</c> or exits via an exception, then this becomes unable to be called again.</td>
         </tr>
 

--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -345,6 +345,8 @@
           <td>A type contextually convertible to <c>bool</c></td>
           <td>Retrieves the text content from its tied character source object, parses the text content, and calls the member functions of its tied table handler object compliantly with the <c>TableHandler</c> requirements.
               Returns <c>false</c> if the return value of a call on <c>empty_physical_line</c>, <c>start_record</c>, <c>end_record</c>, <c>update</c>, or <c>finalize</c> is <c>false</c>; <c>true</c> otherwise.
+              Throws an object of <c>parse_error</c> (<xref id="parse_error"/>) or its derived type if the text content cannot be parsed into a text table (<xref id="definitions.text_table"/>).
+              <span class="note">Implementations are free to exit via an exception on erroneous situations other than this.</span>
               If this returns <c>false</c> or exits via an exception, then this becomes unable to be called again.</td>
         </tr>
 
@@ -879,7 +881,7 @@ namespace commata {
 }
       </codeblock>
 
-      <p>An exception of type <c>parse_error</c> is thrown by the parser, for example by <c>parse_csv</c> (<xref id="parse_csv"/>), when the text does not have an appropriate format.</p>
+      <p>An exception of type <c>parse_error</c> is thrown by a text parser (<xref id="table_parser.requirements"/>) to indicate that the text is not in an appropriate format.</p>
     </section>
   </section>
 

--- a/include/commata/detail/base_parser.hpp
+++ b/include/commata/detail/base_parser.hpp
@@ -204,12 +204,17 @@ yield_2:
         }
 yield_end:
         return true;
+    } catch (const parse_aborted&) {
+        return false;
     } catch (text_error& e) {
         e.set_physical_position(
             physical_line_index_, get_physical_column_index());
         throw;
-    } catch (const parse_aborted&) {
-        return false;
+    } catch (...) {
+        text_error e;
+        e.set_physical_position(
+            physical_line_index_, get_physical_column_index());
+        std::throw_with_nested(std::move(e));
     }
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
This pull request does:
- Clearly specify that `TableParser` should throw `parse_error` on parse errors,
- Clearly specify that `TableParser` may wrap exceptions and rethrow them, and
- Make parsers for both of CSV and TSV wrap exceptions in `text_error` to give them the physical position information.