### PR TITLE
Add a term 'parse point' and facilities to access it

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2025-02-06 (UTC)</signature>
+<signature>2025-02-17 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -64,6 +64,15 @@
         <li>A text record is a sequence of <n>text fields</n>.</li>
         <li>Each text field has its <n>text value</n>, which is a sequence of the char type objects.</li>
       </ul>
+    </section>
+
+    <section id="definitions.parse_point">
+      <name>Parse points</name>
+
+      <p>Every table parser (<xref id="concepts"/>) has its <n>parse point</n> when it is processing a sequence of char-like objects.
+         A parse point refers a char-like object in, or one-past-the-end point, of the sequence currently being processed.
+         It refers the first char-like object when the table parser has just begun processing a non-empty sequence.
+         It never steps back in the sequence while the table parser is consuming the sequence.</p>
     </section>
 
     <section id="definitions.others">
@@ -187,6 +196,7 @@
           <td><p>Evaluated when the parser finds an empty line outside any record.
                  Evaluating this shall occur after an evaluation of (4) and before its corresponding evaluation of (5)
                  and shall not occur between an evaluation of (7) and its corresponding evaluation of (8).</p>
+              <p>When starting evaluating this, the parser shall have its parse point on one past <c>w</c>.</p>
               <p>Here let:</p>
               <ul>
                 <li><c>gb</c> be the return value of the latest evaluation of (2), and</li>
@@ -204,6 +214,7 @@
           <td><c>void</c> or a type contextually convertible to <c>bool</c></td>
           <td><p>Evaluated when the parser begins to process a record.
                  Evaluating this shall occur after an evaluation of (4) and before its corresponding evaluation of (5).</p>
+              <p>When starting evaluating this, the parser shall have its parse point on <c>rb</c>.</p>
               <p>Here let:</p>
               <ul>
                 <li><c>gb</c> be the return value of the latest evaluation of (2), and</li>
@@ -224,6 +235,7 @@
           <td><p>Evaluated when the parser finishes processing a record.
                  Evaluating this shall occur after an evaluation of (7) only once; and
                  after an evaluation of (4) and before its corresponding evaluation of (5).</p>
+              <p>When evaluating this, the parser shall have its parse point on one past <c>re</c>.</p>
               <p>Here let:</p>
               <ul>
                 <li><c>vb</c> be the argument of the latest evaluation of (4) (first argument), (7), (9) (second argument) or (10) (second argument), and</li>
@@ -243,6 +255,8 @@
           <td><c>void</c> or a type contextually convertible to <c>bool</c></td>
           <td><p>Evaluated when the parser finds a non-final chunk of a field value.
                  Evaluating this shall occur after an evaluation of (4) and before its corresponding evaluation of (5), and after an evaluation of (7) and before its corresponding evaluation of (8).</p>
+              <p>When evaluating this, the parser shall have its parse point on or after <c>l</c>.
+                 The first argument of the first evaluation of (8), (9) or (10) next to the evaluation of this shall point a character on or after this parse point.</p>
               <p>Here let:</p>
               <ul>
                 <li><c>vb</c> be the argument of the latest evaluation of (4) (first argument), (7), this (second argument) or (10) (second argument), and</li>
@@ -264,6 +278,8 @@
           <td><c>void</c> or a type contextually convertible to <c>bool</c></td>
           <td><p>Evaluated when the parser finds a final chunk of a field value.
                  Evaluating of this shall occur after an evaluation of (4) and before its corresponding evaluation of (5), and after an evaluation of (7) and before its corresponding evaluation of (8).</p>
+              <p>When evaluating this, the parser shall have its parse point on or after <c>l</c>.
+                 The first argument of the first evaluation of (8), (9) or (10) next to the evaluation of this shall point a character on or after this parse point.</p>
               <p>Here let:</p>
               <ul>
                 <li><c>vb</c> be the argument of the latest evaluation of (4) (first argument), (7), (9) (second argument) or this (second argument), and</li>
@@ -384,7 +400,7 @@
           <td>(4)</td>
           <td><c>ct.get_physical_position()</c></td>
           <td><c>std::pair&lt;std::size_t, std::size_t></c></td>
-          <td>Returns a pair of the physical line number and the physical column number (<xref id="definitions.others"/>).
+          <td>Returns a pair of the physical line number and the physical column number (<xref id="definitions.others"/>) of the current parse point (<xref id="definitions.parse_point"/>).
               The numbers are zero-based.
               <c>-1</c> means shall mean &#x2018;no information&#x2019;.
               Shall not exit via an exception.</td>
@@ -3672,7 +3688,8 @@ template &lt;class Handler, class Allocator = void> using parser_type = <nc>see 
                           <c>std::nothrow_move_constructible_v&lt;P></c> shall be <c>true</c> if <c>std::nothrow_move_constructible_v&lt;CharInput> &amp;&amp; std::nothrow_move_constructible_v&lt;Handler> &amp;&amp; (std::is_void_v&lt;Allocator> || std::nothrow_move_constructible_v&lt;Allocator>)</c> is <c>true</c>.
                           An object of <c>P</c> holds an object of <c>CharInput</c> as its tied character source object and an object of <c>Handler</c> as its tied table handler object.
                           If <c>Handler</c> is deemed to have no buffer control, an object of <c>P</c> also holds an allocator object of <c>Allocator</c> (if not <c>void</c>) or <c>std::allocator&lt;char_type></c> (otherwise), and allocates and deallocates character buffers with it when it requires them.
-                          Invocation of <c>operator()</c> on an object of <c>P</c> might throw <c>parse_error</c> (<xref id="parse_error"/>), <c>std::bad_alloc</c> or any exception thrown by its tied character source object, its tied table handler object, and the allocator object held by it if any.</alias-template>
+                          Invocation of <c>operator()</c> on an object of <c>P</c> might exit via a <c>parse_error</c> (<xref id="parse_error"/>), <c>std::bad_alloc</c> or any exception thrown by its tied character source object, its tied table handler object, and the allocator object held by it if any.
+                          When this invocation exits via a <c>text_error</c> (<xref id="text_error"/>) with a physical position information, the physical position information might represent the current parse point (<xref id="definitions.parse_point"/>).</alias-template>
           <remark>If <c>Handler</c> is deemed to have no buffer control, <c>std::is_same_v&lt;parser_type&lt;Handler>, parser_type&lt;Handler, std::allocator&lt;char_type>>></c> shall be <c>true</c>.</remark>
         </code-item>
       </section>
@@ -3993,7 +4010,8 @@ template &lt;class Handler, class Allocator = void> using parser_type = <nc>see 
                           <c>std::nothrow_move_constructible_v&lt;P></c> shall be <c>true</c> if <c>std::nothrow_move_constructible_v&lt;CharInput> &amp;&amp; std::nothrow_move_constructible_v&lt;Handler> &amp;&amp; (std::is_void_v&lt;Allocator> || std::nothrow_move_constructible_v&lt;Allocator>)</c> is <c>true</c>.
                           An object of <c>P</c> holds an object of <c>CharInput</c> as its tied character source object and an object of <c>Handler</c> as its tied table handler object.
                           If <c>Handler</c> is deemed to have no buffer control, an object of <c>P</c> also holds an allocator object of <c>Allocator</c> (if not <c>void</c>) or <c>std::allocator&lt;char_type></c> (otherwise), and allocates and deallocates character buffers with it when it requires them.
-                          Invocation of <c>operator()</c> on an object of <c>P</c> might throw <c>parse_error</c> (<xref id="parse_error"/>), <c>std::bad_alloc</c> or any exception thrown by its tied character source object, its tied table handler object, and the allocator object held by it if any.</alias-template>
+                          Invocation of <c>operator()</c> on an object of <c>P</c> might exit via a <c>parse_error</c> (<xref id="parse_error"/>), <c>std::bad_alloc</c> or any exception thrown by its tied character source object, its tied table handler object, and the allocator object held by it if any.
+                          When this invocation exits via a <c>text_error</c> (<xref id="text_error"/>) with a physical position information, the physical position information might represent the current parse point (<xref id="definitions.parse_point"/>).</alias-template>
           <remark>If <c>Handler</c> is deemed to have no buffer control, <c>std::is_same_v&lt;parser_type&lt;Handler>, parser_type&lt;Handler, std::allocator&lt;char_type>>></c> shall be <c>true</c>.</remark>
         </code-item>
       </section>

--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2025-02-17 (UTC)</signature>
+<signature>2025-02-18 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -364,7 +364,7 @@
               Throws an object of <c>parse_error</c> (<xref id="parse_error"/>) or its derived type if the text content cannot be parsed into a text table (<xref id="definitions.text_table"/>).
               <span class="note">Implementations are free to exit via an exception on erroneous situations other than this.
                                  To be specific, implementations need not have so-called exception-neutral nature.</span>
-              If this returns <c>false</c> or exits via an exception, then this becomes unable to be called again.</td>
+              If this returns <c>false</c> or exits via an exception, then this ((1)) becomes unable to be called again.</td>
         </tr>
 
         <tr>
@@ -372,6 +372,14 @@
           <td><c>ct.~T()</c></td>
           <td>(Not used)</td>
           <td>Calls <c>release_buffer</c> of its tied table handler object if and only if the latest call of (1) left a buffer obtained with <c>get_buffer</c> of the table handler object unreleased.</td>
+        </tr>
+
+        <tr>
+          <td>(3)</td>
+          <td><c>ct.get_parse_point()</c></td>
+          <td><c>std::size_t</c></td>
+          <td>Returns the number of characters from the first character consumed by the first evaluation of (1) to its current parse point (<xref id="definitions.parse_point"/>).
+              Shall not exit via an exception.</td>
         </tr>
       </table>
 
@@ -390,14 +398,14 @@
         </tr>
 
         <tr>
-          <td>(3)</td>
+          <td>(4)</td>
           <td><c>T::reads_direct</c></td>
           <td>Identical to or derived from <c>std::true_type</c> or <c>std::false_type</c></td>
           <td><c>std::true_type</c> only if any objects of <c>T</c> do not require any buffers to store char-like objects informed to its tied table handler object.</td>
         </tr>
 
         <tr>
-          <td>(4)</td>
+          <td>(5)</td>
           <td><c>ct.get_physical_position()</c></td>
           <td><c>std::pair&lt;std::size_t, std::size_t></c></td>
           <td>Returns a pair of the physical line number and the physical column number (<xref id="definitions.others"/>) of the current parse point (<xref id="definitions.parse_point"/>).
@@ -8090,6 +8098,7 @@ namespace commata {
     <c>// <n><xref id="primitive_table_pull.state"/>, state:</n></c>
     primitive_table_pull_state state() const noexcept;
     explicit operator bool() const noexcept;
+    std::size_t get_parse_point() const noexcept(<nc>see below</nc>);
     std::pair&lt;std::size_t, std::size_t> get_physical_position() const noexcept(<nc>see below</nc>);
     char_type*       operator[](size_type i);
     const char_type* operator[](size_type i) const;
@@ -8352,13 +8361,24 @@ explicit operator bool() const noexcept;
 
       <code-item>
         <code>
+std::size_t get_parse_point() const noexcept(<nc>see below</nc>);
+        </code>
+        <preface>Let <c>p</c> denote the internal table parser object.</preface>
+        <returns><c>p.get_parse_point()</c>.</returns>
+        <throws>Nothing.</throws>
+        <remark>The expression inside <c>noexcept</c> is equivalent to <c>noexcept(p.get_parse_point()))</c>.</remark>
+      </code-item>
+
+      <code-item>
+        <code>
 std::pair&lt;std::size_t, std::size_t> get_physical_position() const noexcept(<nc>see below</nc>);
         </code>
-        <returns>If <c>physical_position_available</c> is <c>true</c>, <c>p.get_physical_position()</c> where <c>p</c> is the internal table parser object.
+        <preface>Let <c>p</c> denote the internal table parser object.</preface>
+        <returns>If <c>physical_position_available</c> is <c>true</c>, <c>p.get_physical_position()</c>.
                  Otherwise, <c>std::make_pair(npos, npos)</c>.</returns>
         <throws>Nothing.</throws>
         <remark>The expression inside <c>noexcept</c> is <c>true</c> if <c>physical_position_available</c> is <c>false</c>.
-                Otherwise, it is equivalent to <c>noexcept(p.get_physical_position()))</c> where <c>p</c> is the internal table parser object.</remark>
+                Otherwise, it is equivalent to <c>noexcept(p.get_physical_position())</c>.</remark>
       </code-item>
 
       <code-item>
@@ -8440,6 +8460,7 @@ namespace commata {
     <c>// <n><xref id="table_pull.state"/>, state:</n></c>
     table_pull_state state() const noexcept;
     explicit operator bool() const noexcept;
+    std::size_t get_parse_point() const noexcept(<nc>see below</nc>);
     std::pair&lt;std::size_t, std::size_t> get_physical_position() const noexcept(<nc>see below</nc>);
     std::pair&lt;std::size_t, std::size_t> get_position() const noexcept;
     const char_type* c_str() const noexcept;
@@ -8607,17 +8628,20 @@ table_pull&amp; skip_record(std::size_t n = 0);
         <code>
 table_pull_state state() const noexcept;
         </code>
-        <returns>A value of <c>table_pull_state</c> that tells the current status of <c>*this</c> as shown in <xref id="table.table_pull.state"/>.</returns>
+        <returns>A value of <c>table_pull_state</c> that tells the current status of <c>*this</c> as shown in <xref id="table.table_pull.state"/>.
+                 In <xref id="table.table_pull.state"/>, a <n>parse events</n> is that the internal table parser invokes one of <c>start_record</c>, <c>end_record</c>, <c>empty_physical_line</c>, <c>update</c> or <c>finalize</c> member functions on its tied table handler specified in the <c>TableHandler</c> requirements (<xref id="table_handler.requirements"/>).</returns>
+        <note>The reason why the latest parse events are specified here is to give practical use to <c>get_parse_point</c> and <c>get_physical_position</c> member functions of this class template.</note>
 
         <table id="table.table_pull.state">
           <caption>The meanings of the values <c>state()</c> returns</caption>
-          <col width="5"/><col width="18"/><col width="81"/><col width="27"/>
+          <col width="4"/><col width="14"/><col width="66"/><col width="27"/><col width="20"/>
 
           <tr>
             <th>#</th>
             <th>Value</th>
             <th>The current status of <c>*this</c></th>
             <th>The current string value</th>
+            <th>The lastest parse event</th>
           </tr>
 
           <tr>
@@ -8625,6 +8649,7 @@ table_pull_state state() const noexcept;
             <td><c>before_parse</c></td>
             <td>Neither <c>operator()</c> nor <c>skip_record</c> has never been called yet.</td>
             <td>An empty string</td>
+            <td>None</td>
           </tr>
 
           <tr>
@@ -8632,6 +8657,7 @@ table_pull_state state() const noexcept;
             <td><c>eof</c></td>
             <td><c>*this</c> has already consumed all content of the table source.</td>
             <td>An empty string</td>
+            <td>Unspecified</td>
           </tr>
 
           <tr>
@@ -8639,6 +8665,7 @@ table_pull_state state() const noexcept;
             <td><c>field</c></td>
             <td><c>*this</c> has reached a text field with the latest call of <c>operator()</c>.</td>
             <td>The text value of the text field</td>
+            <td><c>finalize</c></td>
           </tr>
 
           <tr>
@@ -8646,6 +8673,7 @@ table_pull_state state() const noexcept;
             <td><c>record_end</c></td>
             <td><c>*this</c> has reached an end of the a text record with the latest call of <c>operator()</c> or <c>skip_record</c>.</td>
             <td>An empty string</td>
+            <td><c>end_record</c> or <c>empty_physical_line</c></td>
           </tr>
         </table>
       </code-item>
@@ -8659,13 +8687,24 @@ explicit operator bool() const noexcept;
 
       <code-item>
         <code>
+std::size_t get_parse_point() const noexcept(<nc>see below</nc>);
+        </code>
+        <preface>Let <c>p</c> denote the internal table parser object.</preface>
+        <returns><c>p.get_parse_point()</c>.</returns>
+        <throws>Nothing.</throws>
+        <remark>The expression inside <c>noexcept</c> is equivalent to <c>noexcept(p.get_parse_point()))</c>.</remark>
+      </code-item>
+
+      <code-item>
+        <code>
 std::pair&lt;std::size_t, std::size_t> get_physical_position() const noexcept(<nc>see below</nc>);
         </code>
-        <returns>If <c>physical_position_available</c> is <c>true</c>, <c>p.get_physical_position()</c> where <c>p</c> is the internal table parser object.
+        <preface>Let <c>p</c> denote the internal table parser object.</preface>
+        <returns>If <c>physical_position_available</c> is <c>true</c>, <c>p.get_physical_position()</c>.
                  Otherwise, <c>std::make_pair(npos, npos)</c>.</returns>
         <throws>Nothing.</throws>
         <remark>The expression inside <c>noexcept</c> is <c>true</c> if <c>physical_position_available</c> is <c>false</c>.
-                Otherwise, it is equivalent to <c>noexcept(p.get_physical_position()))</c> where <c>p</c> is the internal table parser object.</remark>
+                Otherwise, it is equivalent to <c>noexcept(p.get_physical_position())</c>.</remark>
       </code-item>
 
       <code-item>

--- a/include/commata/table_pull.hpp
+++ b/include/commata/table_pull.hpp
@@ -548,6 +548,12 @@ public:
         return s != primitive_table_pull_state::eof;
     }
 
+    std::size_t get_parse_point() const
+        noexcept(noexcept(std::declval<const parser_t&>().get_parse_point()))
+    {
+        return ap_.member().get_parse_point();
+    }
+
     primitive_table_pull& operator()()
     {
         assert(!sq_->empty());
@@ -852,6 +858,12 @@ public:
     std::pair<std::size_t, std::size_t> get_position() const noexcept
     {
         return std::make_pair(i_, j_);
+    }
+
+    std::size_t get_parse_point() const
+        noexcept(noexcept(p_.get_parse_point()))
+    {
+        return p_.get_parse_point();
     }
 
     std::pair<std::size_t, std::size_t> get_physical_position() const

--- a/src_test/BaseTest.hpp
+++ b/src_test/BaseTest.hpp
@@ -122,6 +122,13 @@ public:
         return r;
     }
 
+    static std::basic_string<Ch> strv(std::string_view s)
+    {
+        std::basic_string<Ch> r;
+        std::transform(s.cbegin(), s.cend(), std::back_inserter(r), ch);
+        return r;
+    }
+
     template <class T>
     static std::basic_string<Ch> to_string(T value)
     {


### PR DESCRIPTION
So far, `TableParser` optionally have had `get_physical_position`, but its meaning has been not specified clearly.

With this pull request, I would like to introduce a new term 'parse point' to `TableParser` and clearly specify the meaning of `get_physical_position` above.

In the second commit, `get_parse_point` is added to the spec of `TableParser`, its implementations for CSVs and TSVs, and pull parsers (`primitive_table_pull` and `table_pull`). Tests of `table_pull::get_parse_point` are also added.

It is mandatory that `TableParser`s implement the new `get_parse_point`. This is likely to break old codes, to be specific, old parsers written outside of Commata, but I would think this is not a destructive change because defining table parsers other than built-in ones are very rare.