### PR TITLE
[bug] Make empty_physical_line's return values taken into account

### DIFF
--- a/include/commata/detail/base_parser.hpp
+++ b/include/commata/detail/base_parser.hpp
@@ -379,7 +379,7 @@ public:
     {
         assert(!record_started_);
         do_or_abort([this] {
-            f_.empty_physical_line(p_);
+            return f_.empty_physical_line(p_);
         });
     }
 


### PR DESCRIPTION
Commata's built-in parsers (for CSV and TSV) have been wrongly ignoring the return values of `empty_physical_line` of their tied table handlers. This pull request is to fix it.