### PR TITLE
[spec] Fix the CSS, whose 'line-height' for 'pre' elements has not been in effect

### DIFF
--- a/docs/Commata.xsl
+++ b/docs/Commata.xsl
@@ -11,8 +11,7 @@
     <head>
       <title><xsl:apply-templates select="title/node()" mode="title"/></title>
       <style type="text/css"><xsl:text disable-output-escaping="yes">
-        body { margin: 1em 5% 90em 5%; font-family: sans-serif }
-        body * { line-height: 1.3em }
+        body { margin: 1em 5% 90em 5%; font-family: sans-serif; line-height: 1.3em }
         h1 { font-size: 250%; margin-bottom: 0.4em; font-weight: normal }
         h2 { font-size: 220%; margin: 1.6em 0 0.8em 0; font-weight: normal }
         h3 { font-size: 180%; margin: 2em 0 1em 0; font-weight: normal }


### PR DESCRIPTION
Literally.

So far, in the stylesheet of the spec, `pre { line-height: 1.2em }`  has been hidden by `body * { line-height: 1.3em }`. This does not seem desirable (I, however, am not sure because the point of the elaborate selector `body *` is not clear to me any more), so I fix it.