### PR TITLE
Refactor nontrivial_store with reduce visibility of inheritance

### DIFF
--- a/include/commata/field_scanners.hpp
+++ b/include/commata/field_scanners.hpp
@@ -87,7 +87,7 @@ public:
     }
 
 protected:
-    replace_mode& mode() noexcept
+    replace_mode& mode_ref() noexcept
     {
         return mode_;
     }
@@ -107,7 +107,7 @@ protected:
 };
 
 template <class T>
-class nontrivial_store : public trivial_store<T>
+class nontrivial_store : trivial_store<T>
 {
 public:
     using trivial_store<T>::trivial_store;
@@ -153,6 +153,9 @@ public:
         return *this;
     }
 
+    using trivial_store<T>::mode;
+    using trivial_store<T>::value;
+
 private:
     template <class Other>
     void assign(Other&& other)
@@ -174,7 +177,7 @@ private:
         } else if (other.mode() == replace_mode::replace) {
             this->emplace(std::forward<f_t>(other.value()));    // throw
         }
-        this->mode() = other.mode();
+        this->mode_ref() = other.mode();
     }
 
 public:
@@ -195,7 +198,7 @@ public:
             this->emplace(std::move(other.value()));            // throw
             other.value().~T();
         }
-        swap(this->mode(), other.mode());
+        swap(this->mode_ref(), other.mode_ref());
     }
 };
 

--- a/include/commata/text_value_translation.hpp
+++ b/include/commata/text_value_translation.hpp
@@ -669,7 +669,7 @@ protected:
 };
 
 template <class T, unsigned N>
-struct nontrivial_store : trivial_store<T, N>
+struct nontrivial_store : private trivial_store<T, N>
 {
     using trivial_store<T, N>::trivial_store;
 
@@ -719,6 +719,9 @@ struct nontrivial_store : trivial_store<T, N>
         assign(std::move(other));
         return *this;
     }
+
+    using trivial_store<T, N>::size;
+    using trivial_store<T, N>::get;
 
 private:
     template <class Other>


### PR DESCRIPTION
`nontrivial_store<T>` is derived from `trivial_store<T>`, but it is in the so-called 'in-terms-of' manner, so the inheritance should not be `public`. This pull request reduce its visibility to `private`.