### PR TITLE
[bug] Fix bugs in the move ctor of owned_string_input

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2025-04-04 (UTC)</signature>
+<signature>2025-04-25 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -3290,16 +3290,16 @@ explicit owned_string_input(std::basic_string&lt;Ch, Tr, Allocator>&amp;&amp; st
           <code>
 owned_string_input(owned_string_input&amp;&amp; other) noexcept;
           </code>
-          <effects>Initializes <c>s</c> with <c>std::move(other.s)</c>, <c>head</c> with <c>other.head</c> and <c>front</c> with <c>s[head]</c>.
-                   Then assigns <c>other.size()</c> to <c>other.head</c> and <c>other.s[other.head]</c> to <c>other.front</c>.</effects>
+          <effects>Initializes <c>s</c> with <c>std::move(other.s)</c>, <c>head</c> with <c>other.head</c> and <c>front</c> with <c>other.front</c>.
+                   Then assigns <c>other.size()</c> to <c>other.head</c>.</effects>
         </code-item>
 
         <code-item>
           <code>
 owned_string_input&amp; operator=(owned_string_input&amp;&amp; other) noexcept(<nc>see below</nc>);
           </code>
-          <effects>Assigns <c>std::move(other.s)</c> to <c>s</c>, <c>other.head</c> to <c>head</c> and <c>s[head]</c> to <c>front</c>.
-                   Then assigns <c>other.size()</c> to <c>other.head</c> and <c>other.s[other.head]</c> to <c>other.front</c>.</effects>
+          <effects>Assigns <c>std::move(other.s)</c> to <c>s</c>, <c>other.head</c> to <c>head</c> and <c>other.front</c> to <c>front</c>.
+                   Then assigns <c>other.size()</c> to <c>other.head</c>.</effects>
           <remark>The expression inside <c>noexcept</c> is equivalent to <c>std::is_nothrow_move_assignable_v&lt;std::basic_string&lt;Ch, Tr, Allocator>></c>.</remark>
         </code-item>
       </section>

--- a/include/commata/char_input.hpp
+++ b/include/commata/char_input.hpp
@@ -287,8 +287,15 @@ public:
     using size_type = typename string_type::size_type;
 
 private:
+    // Owned string
     std::basic_string<Ch, Tr, Allocator> s_;
+
+    // [0, head_) is the consumed range in s_
     size_type head_;
+
+    // A character that must be written back on s_[head_] prior to the next
+    // read
+    // (s_[head_] may have been overwritten by the reader on the previous read)
     Ch front_;
 
 public:
@@ -312,8 +319,8 @@ public:
 
     owned_string_input(owned_string_input&& other) noexcept :
         s_(std::move(other.s_)),
-        head_(std::exchange(other.head_, other.s_.size())),
-        front_(s_[head_])
+        head_(std::exchange(other.head_, other.s_.size())), // depletes other
+        front_(other.front_)
     {}
 
     ~owned_string_input() = default;
@@ -323,8 +330,8 @@ public:
             std::basic_string<Ch, Tr, Allocator>>)
     {
         s_ = std::move(other.s_);
-        head_ = std::exchange(other.head_, other.s_.size());
-        front_ = std::exchange(other.front_, other.s_[other.head_]);
+        head_ = std::exchange(other.head_, other.s_.size());// depletes other
+        front_ = other.front_;
         return *this;
     }
 


### PR DESCRIPTION
The move ctor of `owned_string_input` has been broken. It has missed set a proper value into `front_` and could have made the input corrupted.

On the other hand, the move assignment operator of it has been sound.

I added tests that can detect this buggy behaviour.
