### PR TITLE
[spec] Make the spec straightforward in terms of the implementation on string_field_translator

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2025-04-25 (UTC)</signature>
+<signature>2025-05-02 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -7594,7 +7594,8 @@ void operator()(const Ch* begin, const Ch* end);
             <code>
 void operator()(std::basic_string&lt;Ch, Tr, Allocator>&amp;&amp; value);
             </code>
-            <effects>If <c>value.get_allocator() == get_allocator()</c>, puts <c>std::move(value)</c> into the field translator sink. Otherwise, calls <c>(*this)(value.c_str(), value.c_str() + value.size())</c>.</effects>
+            <effects>If either <c>std::allocator_traits&lt;Allocator>::is_always_equal::value</c> or <c>value.get_allocator() == get_allocator()</c> is <c>true</c>, puts <c>std::move(value)</c> into the field translator sink.
+                     Otherwise, calls <c>(*this)(value.data(), value.data() + value.size())</c>.</effects>
           </code-item>
 
           <code-item>


### PR DESCRIPTION
Literally. Remove (or relax) divergence in the spec from the implementation of `string_field_translator::operator()` taking an rvalue of `std::basic_string`.