### PR TITLE
Remove unnecessary #include

### DIFF
--- a/include/commata/detail/base_parser.hpp
+++ b/include/commata/detail/base_parser.hpp
@@ -10,7 +10,6 @@
 #include <string_view>
 #include <type_traits>
 
-#include "handler_decorator.hpp"
 #include "../parse_result.hpp"
 
 namespace commata::detail {


### PR DESCRIPTION
Remove `#include "handler_decorator.hpp"` from `"commata/detail/base_parser.hpp"`, which in fact does not reference names declared in `"commata/detail/handler_decorator.hpp"`.