### PR TITLE
[spec][bug] Add #include <utility> to headers that refer std::swap

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2025-05-02 (UTC)</signature>
+<signature>2025-07-12 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -2774,6 +2774,7 @@ template &lt;class InputIterator, class InputIteratorEnd, class OutputIterator>
 #include &lt;string>
 #include &lt;string_view>
 #include &lt;type_traits>
+#include &lt;utility>
 
 namespace commata {
   <c>// <n><xref id="streambuf_input"/>, streambuf_input:</n></c>
@@ -3674,6 +3675,7 @@ std::size_t get_parse_point(const parse_result&amp; r) noexcept;
 #include &lt;cstddef>
 #include &lt;functional>
 #include &lt;memory>
+#include &lt;utility>
 
 #include "parse_error.hpp"
 #include "parse_result.hpp"
@@ -3994,6 +3996,7 @@ template &lt;class Arg1, class Arg2, class... OtherArgs>
 #include &lt;cstddef>
 #include &lt;functional>
 #include &lt;memory>
+#include &lt;utility>
 
 #include "parse_error.hpp"
 #include "parse_result.hpp"


### PR DESCRIPTION
Literally.