### PR TITLE
Enhance assertiveness of codes with [[nodiscard]] with regard to record translators

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2026-03-18 (UTC)</signature>
+<signature>2026-03-24 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -8240,25 +8240,27 @@ namespace commata {
 
   <c>// <n><xref id="field_specs.creation"/>, creation of field specs:</n></c>
   template &lt;class FieldNamePred, class class FieldTranslatorFactory>
-    std::tuple&lt;std::decay_t&lt;FieldNamePred, std::decay_t&lt;FieldTranslatorFactory>>
-      field_spec(FieldNamePred&amp;&amp; field_name_pred, FieldTranslatorFactory&amp;&amp; factory);
+    [[nodiscard]] std::tuple&lt;std::decay_t&lt;FieldNamePred, std::decay_t&lt;FieldTranslatorFactory>>
+        field_spec(FieldNamePred&amp;&amp; field_name_pred, FieldTranslatorFactory&amp;&amp; factory);
   template &lt;class T, class FieldNamePred>
-    std::tuple&lt;std::decay_t&lt;FieldNamePred, default_field_translator_factory&lt;T>>
-      field_spec(FieldNamePred&amp;&amp; field_name_pred);
+    [[nodiscard]] std::tuple&lt;std::decay_t&lt;FieldNamePred, default_field_translator_factory&lt;T>>
+        field_spec(FieldNamePred&amp;&amp; field_name_pred);
   template &lt;class T, class FieldNamePred>
-    std::tuple&lt;std::decay_t&lt;FieldNamePred, locale_based_arithmetic_field_translator_factory&lt;T>>
-      field_spec(FieldNamePred&amp;&amp; field_name_pred, const std::locale&amp; loc);
+    [[nodiscard]]
+      std::tuple&lt;std::decay_t&lt;FieldNamePred, locale_based_arithmetic_field_translator_factory&lt;T>>
+        field_spec(FieldNamePred&amp;&amp; field_name_pred, const std::locale&amp; loc);
 
   <c>// <n><xref id="record_translators.creation"/>, creation of record translators:</n></c>
   template &lt;class Ch, class Tr, class Allocator, class FR, class... FieldSpecRs>
-    basic_table_scanner&lt;Ch, Tr, Allocator> make_basic_record_translator(
+    [[nodiscard]] basic_table_scanner&lt;Ch, Tr, Allocator> make_basic_record_translator(
       std::allocator_arg_t, const Allocator&amp; alloc, FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
   template &lt;class Ch, class Tr, class FR, class... FieldSpecRs>
-    basic_table_scanner&lt;Ch, Tr> make_basic_record_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
+    [[nodiscard]] basic_table_scanner&lt;Ch, Tr> make_basic_record_translator(
+      FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
   template &lt;class FR, class... FieldSpecRs>
-    table_scanner make_record_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
+    [[nodiscard]] table_scanner make_record_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
   template &lt;class FR, class... FieldSpecRs>
-    wtable_scanner make_wrecord_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
+    [[nodiscard]] wtable_scanner make_wrecord_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
       </codeblock>
       <p>The header <c>"commama/record_translator.hpp"</c> defines facilities to make a <n>record translator</n> object, which is a <c>basic_table_scanner</c> object configured to invoke its associated function object with translated text values (<xref id="xlate.general"/>) of text fields once every record.</p>
     </section>
@@ -8663,7 +8665,7 @@ using type = <nc>see below</nc>;
       <code-item>
         <code>
 template &lt;class FieldNamePred, class class FieldTranslatorFactory>
-  std::tuple&lt;std::decay_t&lt;FieldNamePred, std::decay_t&lt;FieldTranslatorFactory>>
+  [[nodiscard]] std::tuple&lt;std::decay_t&lt;FieldNamePred, std::decay_t&lt;FieldTranslatorFactory>>
     field_spec(FieldNamePred&amp;&amp; field_name_pred, FieldTranslatorFactory&amp;&amp; factory);
         </code>
         <effects><p>Equivalent to:</p>
@@ -8675,7 +8677,7 @@ template &lt;class FieldNamePred, class class FieldTranslatorFactory>
       <code-item>
         <code>
 template &lt;class T, class FieldNamePred>
-  std::tuple&lt;std::decay_t&lt;FieldNamePred, default_field_translator_factory_t&lt;T>>
+  [[nodiscard]] std::tuple&lt;std::decay_t&lt;FieldNamePred, default_field_translator_factory_t&lt;T>>
     field_spec(FieldNamePred&amp;&amp; field_name_pred);
         </code>
         <effects><p>Equivalent to:</p>
@@ -8686,8 +8688,9 @@ template &lt;class T, class FieldNamePred>
       <code-item>
         <code>
 template &lt;class T, class FieldNamePred>
-  std::tuple&lt;std::decay_t&lt;FieldNamePred, locale_based_arithmetic_field_translator_factory&lt;T>>
-    field_spec(FieldNamePred&amp;&amp; field_name_pred, const std::locale&amp; loc);
+  [[nodiscard]]
+    std::tuple&lt;std::decay_t&lt;FieldNamePred, locale_based_arithmetic_field_translator_factory&lt;T>>
+      field_spec(FieldNamePred&amp;&amp; field_name_pred, const std::locale&amp; loc);
         </code>
         <effects><p>Equivalent to:</p>
                  <code>return { std::forward&lt;FieldNamePred>(field_name_pred),
@@ -8764,10 +8767,10 @@ template &lt;class T, class FieldNamePred>
       <code-item>
         <code>
 template &lt;class Ch, class Tr, class Allocator, class FR, class... FieldSpecRs>
-  basic_table_scanner&lt;Ch, Tr, Allocator> make_basic_record_translator(
+  [[nodiscard]] basic_table_scanner&lt;Ch, Tr, Allocator> make_basic_record_translator(
     std::allocator_arg_t, const Allocator&amp; alloc, FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
 template &lt;class Ch, class Tr, class FR, class... FieldSpecRs>
-  basic_table_scanner&lt;Ch, Tr> make_basic_record_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
+  [[nodiscard]] basic_table_scanner&lt;Ch, Tr> make_basic_record_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
         </code>
         <preface>Let <c>FieldSpecs</c> be a pack formed with <c>std::decay_t&lt;FieldSpecRs>...</c>
                  and <c>TableScanner</c> be <c>basic_table_scanner&lt;Ch, Tr, Allocator></c> (in the first form) or <c>basic_table_scanner&lt;Ch, Tr></c> (in the second form).</preface>
@@ -8813,7 +8816,7 @@ template &lt;class Ch, class Tr, class FR, class... FieldSpecRs>
       <code-item>
         <code>
 template &lt;class FR, class... FieldSpecRs>
-  table_scanner make_record_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
+  [[nodiscard]] table_scanner make_record_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
         </code>
         <effects><p>Equivalent to:</p>
                  <code>return make_basic_record_translator&lt;char, std::char_traits&lt;char>>(
@@ -8823,7 +8826,7 @@ template &lt;class FR, class... FieldSpecRs>
       <code-item>
         <code>
 template &lt;class FR, class... FieldSpecRs>
-  wtable_scanner make_wrecord_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
+  [[nodiscard]] wtable_scanner make_wrecord_translator(FR&amp;&amp; f, FieldSpecRs&amp;&amp;... specs);
         </code>
         <effects><p>Equivalent to:</p>
                  <code>return make_basic_record_translator&lt;wchar_t, std::char_traits&lt;wchar_t>>(

--- a/include/commata/detail/allocate_deallocate.hpp
+++ b/include/commata/detail/allocate_deallocate.hpp
@@ -8,6 +8,7 @@
 
 #include <cassert>
 #include <memory>
+#include <type_traits>
 
 namespace commata::detail {
 
@@ -72,7 +73,10 @@ void destroy_deallocate_g_static(const Allocator& alloc, P p)
 template <class Allocator, class P>
 void destroy_deallocate_g_dynamic(const Allocator& alloc, P p)
 {
+    static_assert(
+        std::is_polymorphic_v<std::remove_reference_t<decltype(*p)>>);
     assert(p);
+
     destroy_deallocate_g_impl(alloc, p, p->size_of());
 }
 

--- a/include/commata/record_translator.hpp
+++ b/include/commata/record_translator.hpp
@@ -240,7 +240,8 @@ using default_field_translator_factory_t =
     typename default_field_translator_factory<T>::type;
 
 template <class FieldNamePred, class FieldTranslatorFactory>
-auto field_spec(FieldNamePred&& field_name_pred, FieldTranslatorFactory&& factory)
+[[nodiscard]] auto field_spec(
+        FieldNamePred&& field_name_pred, FieldTranslatorFactory&& factory)
  -> std::enable_if_t<
         !std::is_base_of_v<std::locale, std::decay_t<FieldTranslatorFactory>>,
         std::tuple<std::decay_t<FieldNamePred>,
@@ -251,7 +252,8 @@ auto field_spec(FieldNamePred&& field_name_pred, FieldTranslatorFactory&& factor
 }
 
 template <class T, class FieldNamePred>
-std::tuple<std::decay_t<FieldNamePred>, default_field_translator_factory_t<T>>
+[[nodiscard]] std::tuple<std::decay_t<FieldNamePred>,
+                         default_field_translator_factory_t<T>>
     field_spec(FieldNamePred&& field_name_pred)
 {
     return { std::forward<FieldNamePred>(field_name_pred),
@@ -259,7 +261,8 @@ std::tuple<std::decay_t<FieldNamePred>, default_field_translator_factory_t<T>>
 }
 
 template <class T, class FieldNamePred>
-auto field_spec(FieldNamePred&& field_name_pred, const std::locale& loc)
+[[nodiscard]] auto field_spec(
+        FieldNamePred&& field_name_pred, const std::locale& loc)
  -> std::enable_if_t<
         is_default_translatable_arithmetic_type_v<T>,
         std::tuple<std::decay_t<FieldNamePred>,
@@ -620,9 +623,10 @@ basic_table_scanner<Ch, Tr, Allocator> make_basic_record_translator_impl(
 }
 
 template <class Ch, class Tr, class Allocator, class FR, class... FieldSpecRs>
-basic_table_scanner<Ch, Tr, Allocator> make_basic_record_translator(
-    std::allocator_arg_t, const Allocator& alloc,
-    FR&& f, FieldSpecRs&&... specs)
+[[nodiscard]] basic_table_scanner<Ch, Tr, Allocator>
+    make_basic_record_translator(
+        std::allocator_arg_t, const Allocator& alloc,
+        FR&& f, FieldSpecRs&&... specs)
 {
     return detail::record_xlate::
         make_basic_record_translator_impl<Ch, Tr, true>(
@@ -630,7 +634,7 @@ basic_table_scanner<Ch, Tr, Allocator> make_basic_record_translator(
 }
 
 template <class Ch, class Tr, class FR, class... FieldSpecRs>
-auto make_basic_record_translator(FR&& f, FieldSpecRs&&... specs)
+[[nodiscard]] auto make_basic_record_translator(FR&& f, FieldSpecRs&&... specs)
  -> std::enable_if_t<
         !std::is_base_of_v<std::allocator_arg_t, std::decay_t<FR>>,
         basic_table_scanner<Ch, Tr>>
@@ -642,14 +646,16 @@ auto make_basic_record_translator(FR&& f, FieldSpecRs&&... specs)
 }
 
 template <class FR, class... FieldSpecRs>
-table_scanner make_record_translator(FR&& f, FieldSpecRs&&... specs)
+[[nodiscard]] table_scanner
+    make_record_translator(FR&& f, FieldSpecRs&&... specs)
 {
     return make_basic_record_translator<char, std::char_traits<char>>(
         std::forward<FR>(f), std::forward<FieldSpecRs>(specs)...);
 }
 
 template <class FR, class... FieldSpecRs>
-wtable_scanner make_wrecord_translator(FR&& f, FieldSpecRs&&... specs)
+[[nodiscard]] wtable_scanner
+    make_wrecord_translator(FR&& f, FieldSpecRs&&... specs)
 {
     return make_basic_record_translator<wchar_t, std::char_traits<wchar_t>>(
         std::forward<FR>(f), std::forward<FieldSpecRs>(specs)...);

--- a/include/commata/record_translator.hpp
+++ b/include/commata/record_translator.hpp
@@ -456,7 +456,7 @@ private:
     }
 
     template <class FieldSpecR, class U>
-    auto create_setter(FieldSpecR&& spec, std::optional<U>& o)
+    [[nodiscard]] auto create_setter(FieldSpecR&& spec, std::optional<U>& o)
     {
         if constexpr (UsesAllocatorForPred) {
             typename at_t::template rebind_alloc<Ch> a(m_.get_allocator());
@@ -475,7 +475,8 @@ private:
     }
 
     template <class Pred, class Factory, class U>
-    auto create_setter_core(Pred&& pred, Factory&& fac, std::optional<U>& o)
+    [[nodiscard]] auto create_setter_core(
+        Pred&& pred, Factory&& fac, std::optional<U>& o)
     {
         using typed_t = typed_field_scanner_setter<
             std::decay_t<Pred>, std::decay_t<Factory>, Ch, Tr, Allocator>;
@@ -485,7 +486,7 @@ private:
     }
 
 public:
-    bool operator()(
+    [[nodiscard]] bool operator()(
         std::size_t field_index,
         std::optional<std::pair<const Ch*, const Ch*>> field_value,
         basic_table_scanner<Ch, Tr, Allocator>& scanner)
@@ -571,7 +572,7 @@ public:
     }
 
     template <class... FieldSpecRs>
-    auto make_header_field_scanner(FieldSpecRs&&... specs)
+    [[nodiscard]] auto make_header_field_scanner(FieldSpecRs&&... specs)
     {
         return h_t(std::allocator_arg, Allocator(this->get()),
             *field_values_, std::forward<FieldSpecRs>(specs)...);
@@ -603,8 +604,9 @@ private:
 
 template <class Ch, class Tr, bool UsesAllocatorForPred, class Allocator,
           class FR, class... FieldSpecRs>
-basic_table_scanner<Ch, Tr, Allocator> make_basic_record_translator_impl(
-    const Allocator& alloc, FR&& f, FieldSpecRs&&... specs)
+[[nodiscard]] basic_table_scanner<Ch, Tr, Allocator>
+    make_basic_record_translator_impl(
+        const Allocator& alloc, FR&& f, FieldSpecRs&&... specs)
 {
     using table_scanner_t = basic_table_scanner<Ch, Tr, Allocator>;
     using record_end_scanner_t =


### PR DESCRIPTION
Commata has employed `[[nodiscard]]` rather eagerly, but I have forgotten specify them with regard to `record_translator.hpp`. This pull request takes care of it.