### PR TITLE
Fix the searching order of the matching field spec in record_translator_header_field_scanner

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2026-03-25 (UTC)</signature>
+<signature>2026-05-01 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -8751,8 +8751,9 @@ template &lt;class T, class FieldNamePred>
           <ul>
             <li>(1) if <c>v.has_value()</c> evaluates to <c>true</c>:
                 <ul>
-                  <li>(1a) if the predicate <c>field_name_preds[i]</c> evaluates to <c>true</c> on [<c>v->first</c>, <c>v->second</c>) for a certain integer value <c>i</c> in [<c>0</c>, <c>N</c>) that never appeared as <c>i</c> itself in the preceding occurrences of this (that is, (1a)) so far,
-                    then evaluates <c>t.set_field_scanner(j, std::move(factories[i])(rp(i)))</c> and returns <c>true</c>,</li>
+                  <li>(1a) if the predicate <c>field_name_preds[i]</c> evaluates to <c>true</c> on [<c>v->first</c>, <c>v->second</c>) for a certain integer value <c>i</c> in [<c>0</c>, <c>N</c>) that never appeared as <c>imin</c> in the preceding occurrences of this (that is, (1a)) so far,
+                    then evaluates <c>t.set_field_scanner(j, std::move(factories[i])(rp(imin)))</c> where <c>imin</c> is the minimum of the qualified values of <c>i</c>,
+                    and returns <c>true</c>,</li>
                   <li>(1b) otherwise, then simply returns <c>true</c>,</li>
                 </ul>
             </li>

--- a/include/commata/record_translator.hpp
+++ b/include/commata/record_translator.hpp
@@ -374,7 +374,7 @@ class record_translator_header_field_scanner
     using m_value_a_t = typename at_t::template rebind_alloc<m_value_t>;
     using m_t = std::vector<m_value_t, m_value_a_t>;
 
-    m_t m_; // has field_scanner_setter in reverse order
+    m_t m_;
 
 public:
     template <class... FieldSpecRs>
@@ -476,15 +476,16 @@ public:
             const std::basic_string_view<Ch, Tr> field_name(
                 field_value->first,
                 field_value->second - field_value->first);
-            // reverse order seach of reversely ordered container m_
-            for (decltype(m_.size()) i = m_.size(); i > 0U; --i) {
-                const auto ii = i - 1;
-                auto& setter = *m_[ii];
+            decltype(m_.size()) i = 0U, ie = m_.size();
+            while (i < ie) {
+                auto& setter = *m_[i];
                 if (setter.matches(field_index, field_name)) {
                     std::move(setter).set(field_index, scanner);
-                    destroy_deallocate(m_[ii]);
-                    m_.erase(m_.begin() + ii);
-                        // makes duplicate fields ignored
+                    destroy_deallocate(m_[i]);
+                    m_.erase(m_.begin() + i);
+                    break;
+                } else {
+                    ++i;
                 }
             }
             return true;

--- a/src_test/TestRecordTranslator.cpp
+++ b/src_test/TestRecordTranslator.cpp
@@ -152,6 +152,30 @@ TEST_F(TestRecordTranslator, Allocators)
         // #3: making of a100 + "\n-10"
 }
 
+TEST_F(TestRecordTranslator, Duplication)
+{
+    std::string s1;
+    double s2;
+    int s3;
+
+    auto t = make_record_translator(
+        [&s1, &s2, &s3](std::string&& f1, double f2, int f3) {
+            std::tie(s1, s2, s3) =
+                std::forward_as_tuple(std::move(f1), f2, f3);
+        },
+        field_spec<std::string>("ABC"),
+        field_spec<double>("ABC"),
+        field_spec<int>("ABC"));
+    parse_tsv(
+        make_char_input(
+            "ABC\tABC\tABC\n"
+            "1\t2\t3\n"),
+        std::move(t));
+    ASSERT_EQ("1"sv, s1);
+    ASSERT_EQ(2.0, s2);
+    ASSERT_EQ(3, s3);
+}
+
 // Compile-time tests of deduction guides
 
 static_assert(std::is_same_v<


### PR DESCRIPTION
First, `record_translator_header_field_scanner::operator()` was buggy because it made the table scanner discard (or destroy silently) 'excess' field specs that appeared after another field spec which matched the same field name.

Second, the spec was not clear on which field spec should be selected when multiple field specs qualified.

This pull request will fix the implementation (which was 'discarded' field specs wrongly) and the spec (which was not clear).