### PR TITLE
Reduce move construction of translated values by record translators

### DIFF
--- a/include/commata/detail/tuple_transform.hpp
+++ b/include/commata/detail/tuple_transform.hpp
@@ -16,25 +16,31 @@
 namespace commata::detail {
 
 template <std::size_t I, class F, class... Tuples>
-constexpr auto apply(F f, Tuples&&... t) {
-    return std::invoke(f, std::get<I>(std::forward<Tuples>(t))...);
+constexpr decltype(auto) apply(F&& f, Tuples&&... t)
+{
+    return std::invoke(std::forward<F>(f),
+                       std::get<I>(std::forward<Tuples>(t))...);
 }
 
 template <std::size_t... Is, class F, class... Tuples>
 constexpr auto transform_impl(std::index_sequence<Is...>,
-        [[maybe_unused]] F f, [[maybe_unused]] Tuples&&... ts) {
-    return std::make_tuple(apply<Is>(f, std::forward<Tuples>(ts)...)...);
+    [[maybe_unused]] F&& f, [[maybe_unused]] Tuples&&... ts)
+{
+    using r_t = std::tuple<decltype(
+        apply<Is>(std::forward<F>(f), std::forward<Tuples>(ts)...))...>;
+    return r_t(apply<Is>(std::forward<F>(f), std::forward<Tuples>(ts)...)...);
 }
 
 template <class F, class... Tuples>
-constexpr auto transform(F f, Tuples&&... ts) {
+constexpr auto transform(F&& f, Tuples&&... ts)
+{
     constexpr auto size_min =
         std::min({std::tuple_size_v<std::decay_t<Tuples>>...});
     constexpr auto size_max =
         std::max({std::tuple_size_v<std::decay_t<Tuples>>...});
     static_assert(size_min == size_max, "Inconsistent tuple sizes");
     return transform_impl(std::make_index_sequence<size_min>(),
-                          std::move(f), std::forward<Tuples>(ts)...);
+                          std::forward<F>(f), std::forward<Tuples>(ts)...);
 }
 
 }

--- a/include/commata/record_translator.hpp
+++ b/include/commata/record_translator.hpp
@@ -565,7 +565,7 @@ public:
         std::apply(
             f_,
             transform(
-                [](auto& v) { return std::move(v).unwrap(); },
+                [](auto& v) -> decltype(auto) { return std::move(v).unwrap(); },
                 *field_values_));
     }
 


### PR DESCRIPTION
This may be a very subtle change.

This makes each translated text field value object not moved, after its creation, before the invocation of the record handler object.