### PR TITLE
Squelch VS2022, which blames the codes as a double-forward

### DIFF
--- a/include/commata/detail/tuple_transform.hpp
+++ b/include/commata/detail/tuple_transform.hpp
@@ -27,7 +27,7 @@ constexpr auto transform_impl(std::index_sequence<Is...>,
     [[maybe_unused]] F&& f, [[maybe_unused]] Tuples&&... ts)
 {
     using r_t = std::tuple<decltype(
-        apply<Is>(std::forward<F>(f), std::forward<Tuples>(ts)...))...>;
+        apply<Is>(std::declval<F&&>(), std::declval<Tuples&&>()...))...>;
     return r_t(apply<Is>(std::forward<F>(f), std::forward<Tuples>(ts)...)...);
 }
 


### PR DESCRIPTION
When we write `decltype(...std::forward<F>(f)...)`, `std::forward<F>(f)` shall not be evaluated. But it seems that VS2022 recognizes this as a real forwarding and blames the following `std::forward<F>(f)` (outside `decltype`) as a double-forward.

This pull request is to employ `std::declval<F&&>` in place of `std::forward<F>(f)` in `decltype` to tell VS2022 that this is not a real forwarding.