### PR TITLE
Add line breaks to shorten a too long line in record_translator.hpp

### DIFF
--- a/include/commata/record_translator.hpp
+++ b/include/commata/record_translator.hpp
@@ -565,7 +565,9 @@ public:
         std::apply(
             f_,
             transform(
-                [](auto& v) -> decltype(auto) { return std::move(v).unwrap(); },
+                [](auto& v) -> decltype(auto) {
+                    return std::move(v).unwrap();
+                },
                 *field_values_));
     }
 


### PR DESCRIPTION
The slightest change. #125 made a too long line and this pull request breaks it into shorter lines.