### PR TITLE
Remove a default template param of make_basic_record_translator_impl

### DIFF
--- a/include/commata/record_translator.hpp
+++ b/include/commata/record_translator.hpp
@@ -584,7 +584,7 @@ private:
     }
 };
 
-template <class Ch, class Tr = std::char_traits<Ch>, bool UsesAllocatorForPred,
+template <class Ch, class Tr, bool UsesAllocatorForPred,
           class Allocator, class FR, class... FieldSpecRs>
 [[nodiscard]] basic_table_scanner<Ch, Tr, Allocator>
     make_basic_record_translator_impl(


### PR DESCRIPTION
Literally. It was simply unnecessary.