### PR TITLE
Make fail/ignore/replace convertible from tags

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2026-05-01 (UTC)</signature>
+<signature>2026-06-06 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -1936,7 +1936,7 @@ namespace commata {
         <codeblock>
 namespace commata {
   struct fail_if_conversion_failed {
-    explicit fail_if_conversion_failed(replacement_fail_t = replacement_fail) {}
+    fail_if_conversion_failed(replacement_fail_t = replacement_fail) {}
 
     template &lt;class T, class Ch>
       [[noreturn]] T operator()(invalid_format_t, const Ch*, const Ch*, T* = nullptr) const;
@@ -1982,7 +1982,7 @@ template &lt;class T>
         <codeblock>
 namespace commata {
   struct ignore_if_conversion_failed {
-    explicit ignore_if_conversion_failed(replacement_ignore_t = replacement_ignore) {}
+    ignore_if_conversion_failed(replacement_ignore_t = replacement_ignore) {}
 
     std::nullopt_t operator()(invalid_format_t) const;
     std::nullopt_t operator()(out_of_range_t) const;
@@ -7117,7 +7117,7 @@ namespace commata {
         <codeblock>
 namespace commata {
   struct fail_if_skipped {
-    explicit fail_if_skipped(replacement_fail_t = replacement_fail) {}
+    fail_if_skipped(replacement_fail_t = replacement_fail) {}
     template &lt;class T> [[noreturn]] T operator()(T* = nullptr) const;
   };
 }
@@ -7140,7 +7140,7 @@ template &lt;class T> [[noreturn]] T operator()(T* = nullptr) const;
         <codeblock>
 namespace commata {
   struct ignore_if_skipped {
-    explicit ignore_if_skipped(replacement_ignore_t = replacement_ignore) {}
+    ignore_if_skipped(replacement_ignore_t = replacement_ignore) {}
     std::nullopt_t operator()() const;
   };
 }

--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2026-06-06 (UTC)</signature>
+<signature>2026-06-07 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -2137,7 +2137,8 @@ template &lt;class All = T>
             <effects>Arranges all configurable replacement actions from <c>for_all</c>.</effects>
             <remark>This overload shall not participate in overload resolution unless <c><nc>IS_ACCEPTABLE</nc>&lt;const All&amp;></c> is <c>true</c>.
                     The expression inside <c>noexcept</c> is equvalent to <c><nc>IS_NOTHROW_ACCEPTABLE</nc>&lt;T, const All&amp;></c>.
-                    This constructor is explicit if and only if <c>std::is_convertible_v&lt;const All&amp;, T></c> is <c>false</c>.</remark>
+                    This constructor is explicit if and only if <c>All</c> is either <c>replacement_fail_t</c> or <c>replacement_ignore_t</c>,
+                    or <c>std::is_convertible_v&lt;const All&amp;, T></c> is <c>false</c>.</remark>
           </code-item>
 
           <code-item>

--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -1936,7 +1936,7 @@ namespace commata {
         <codeblock>
 namespace commata {
   struct fail_if_conversion_failed {
-    fail_if_conversion_failed(replacement_fail_t = replacement_fail) {}
+    explicit fail_if_conversion_failed(replacement_fail_t = replacement_fail) {}
 
     template &lt;class T, class Ch>
       [[noreturn]] T operator()(invalid_format_t, const Ch*, const Ch*, T* = nullptr) const;
@@ -1982,7 +1982,7 @@ template &lt;class T>
         <codeblock>
 namespace commata {
   struct ignore_if_conversion_failed {
-    ignore_if_conversion_failed(replacement_ignore_t = replacement_ignore) {}
+    explicit ignore_if_conversion_failed(replacement_ignore_t = replacement_ignore) {}
 
     std::nullopt_t operator()(invalid_format_t) const;
     std::nullopt_t operator()(out_of_range_t) const;
@@ -2017,7 +2017,7 @@ namespace commata {
 
     <c>// <n><xref id="replace_if_conversion_failed.cons"/>, construct/copy/destroy:</n></c>
     template &lt;class All = T>
-      replace_if_conversion_failed(const All&amp; for_all = All()) noexcept(<nc>see below</nc>);
+      <nc>EXPLICIT</nc> replace_if_conversion_failed(const All&amp; for_all = All()) noexcept(<nc>see below</nc>);
     template &lt;class Empty, class AllButEmpty>
       replace_if_conversion_failed(Empty&amp;&amp;            on_empty,
                                    const AllButEmpty&amp; for_all_but_empty) noexcept(<nc>see below</nc>);
@@ -2132,11 +2132,12 @@ static constexpr std::size_t size = <nc>see below</nc>;
           <code-item>
             <code>
 template &lt;class All = T>
-  replace_if_conversion_failed(const All&amp; for_all = All()) noexcept(<nc>see below</nc>);
+  <nc>EXPLICIT</nc> replace_if_conversion_failed(const All&amp; for_all = All()) noexcept(<nc>see below</nc>);
             </code>
             <effects>Arranges all configurable replacement actions from <c>for_all</c>.</effects>
             <remark>This overload shall not participate in overload resolution unless <c><nc>IS_ACCEPTABLE</nc>&lt;const All&amp;></c> is <c>true</c>.
-                    The expression inside <c>noexcept</c> is equvalent to <c><nc>IS_NOTHROW_ACCEPTABLE</nc>&lt;T, const All&amp;></c>.</remark>
+                    The expression inside <c>noexcept</c> is equvalent to <c><nc>IS_NOTHROW_ACCEPTABLE</nc>&lt;T, const All&amp;></c>.
+                    This constructor is explicit if and only if <c>std::is_convertible_v&lt;const All&amp;, T></c> is <c>false</c>.</remark>
           </code-item>
 
           <code-item>
@@ -7116,7 +7117,7 @@ namespace commata {
         <codeblock>
 namespace commata {
   struct fail_if_skipped {
-    fail_if_skipped(replacement_fail_t = replacement_fail) {}
+    explicit fail_if_skipped(replacement_fail_t = replacement_fail) {}
     template &lt;class T> [[noreturn]] T operator()(T* = nullptr) const;
   };
 }
@@ -7139,7 +7140,7 @@ template &lt;class T> [[noreturn]] T operator()(T* = nullptr) const;
         <codeblock>
 namespace commata {
   struct ignore_if_skipped {
-    ignore_if_skipped(replacement_ignore_t = replacement_ignore) {}
+    explicit ignore_if_skipped(replacement_ignore_t = replacement_ignore) {}
     std::nullopt_t operator()() const;
   };
 }
@@ -7167,9 +7168,9 @@ namespace commata {
 
     <c>// <n><xref id="replace_if_skipped.cons"/>, construct/copy/destroy:</n></c>
     template &lt;class U = T>
-      replace_if_skipped(U&amp;&amp; u = std::decay_t&lt;U>()) noexcept(<nc>see below</nc>);
-    replace_if_skipped(replacement_fail_t) noexcept;
-    replace_if_skipped(replacement_ignore_t) noexcept;
+      <nc>EXPLICIT</nc> replace_if_skipped(U&amp;&amp; u = std::decay_t&lt;U>()) noexcept(<nc>see below</nc>);
+    explicit replace_if_skipped(replacement_fail_t) noexcept;
+    explicit replace_if_skipped(replacement_ignore_t) noexcept;
     replace_if_skipped(const replace_if_skipped&amp;  other) noexcept(<nc>see below</nc>);
     replace_if_skipped(      replace_if_skipped&amp;&amp; other) noexcept(<nc>see below</nc>);
    ~replace_if_skipped();
@@ -7206,26 +7207,27 @@ namespace commata {
           <code-item>
             <code>
 template &lt;class U = T>
-  replace_if_skipped(U&amp;&amp; u = std::decay_t&lt;U>()) noexcept(<nc>see below</nc>);
+  <nc>EXPLICIT</nc> replace_if_skipped(U&amp;&amp; u = std::decay_t&lt;U>()) noexcept(<nc>see below</nc>);
             </code>
             <effects>Configures the replacement action to be <c>copy</c> with an object of <c>T</c> constructed from <c>std::forward&lt;U>(u)</c>.</effects>
             <remark>This constructor shall not participate in overload resolution unless <c>std::is_constructible_v&lt;T, U></c> is <c>true</c>,
                     <c>std::is_base_of_v&lt;replace_if_skipped&lt;T>, std::decay&lt;U>></c> is <c>false</c>,
                     <c>std::is_base_of_v&lt;replacement_fail_t, std::decay&lt;U>></c> is <c>false</c>, and
                     <c>std::is_base_of_v&lt;replacement_ignore_t, std::decay&lt;U>></c> is <c>false</c>.
-                    The expression inside <c>noexcept</c> is equivalent to <c>std::is_nothrow_constructible_v&lt;T, U></c>.</remark>
+                    The expression inside <c>noexcept</c> is equivalent to <c>std::is_nothrow_constructible_v&lt;T, U></c>.
+                    This constructor is explicit if and only if <c>std::is_convertible_v&lt;U&amp;&amp;, T></c> is <c>false</c>.</remark>
           </code-item>
 
           <code-item>
             <code>
-replace_if_skipped(replacement_fail_t) noexcept;
+explicit replace_if_skipped(replacement_fail_t) noexcept;
             </code>
             <effects>Configures the replacement action to be <c>fail</c>.</effects>
           </code-item>
 
           <code-item>
             <code>
-replace_if_skipped(replacement_ignore_t) noexcept;
+explicit replace_if_skipped(replacement_ignore_t) noexcept;
             </code>
             <effects>Configures the replacement action to be <c>ignore</c>.</effects>
           </code-item>

--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -7169,8 +7169,8 @@ namespace commata {
     <c>// <n><xref id="replace_if_skipped.cons"/>, construct/copy/destroy:</n></c>
     template &lt;class U = T>
       <nc>EXPLICIT</nc> replace_if_skipped(U&amp;&amp; u = std::decay_t&lt;U>()) noexcept(<nc>see below</nc>);
-    explicit replace_if_skipped(replacement_fail_t) noexcept;
-    explicit replace_if_skipped(replacement_ignore_t) noexcept;
+    replace_if_skipped(replacement_fail_t) noexcept;
+    replace_if_skipped(replacement_ignore_t) noexcept;
     replace_if_skipped(const replace_if_skipped&amp;  other) noexcept(<nc>see below</nc>);
     replace_if_skipped(      replace_if_skipped&amp;&amp; other) noexcept(<nc>see below</nc>);
    ~replace_if_skipped();
@@ -7220,14 +7220,14 @@ template &lt;class U = T>
 
           <code-item>
             <code>
-explicit replace_if_skipped(replacement_fail_t) noexcept;
+replace_if_skipped(replacement_fail_t) noexcept;
             </code>
             <effects>Configures the replacement action to be <c>fail</c>.</effects>
           </code-item>
 
           <code-item>
             <code>
-explicit replace_if_skipped(replacement_ignore_t) noexcept;
+replace_if_skipped(replacement_ignore_t) noexcept;
             </code>
             <effects>Configures the replacement action to be <c>ignore</c>.</effects>
           </code-item>

--- a/include/commata/field_scanners.hpp
+++ b/include/commata/field_scanners.hpp
@@ -31,7 +31,7 @@ public:
 
 struct fail_if_skipped
 {
-    explicit fail_if_skipped(replacement_fail_t = replacement_fail)
+    fail_if_skipped(replacement_fail_t = replacement_fail)
     {}
 
     template <class T>
@@ -45,7 +45,7 @@ struct fail_if_skipped
 
 struct ignore_if_skipped
 {
-    explicit ignore_if_skipped(replacement_ignore_t = replacement_ignore)
+    ignore_if_skipped(replacement_ignore_t = replacement_ignore)
     {}
 
     std::nullopt_t operator()() const

--- a/include/commata/field_scanners.hpp
+++ b/include/commata/field_scanners.hpp
@@ -259,11 +259,11 @@ public:
         store_(generic_args_t(), std::forward<U>(u))
     {}
 
-    explicit replace_if_skipped(replacement_fail_t) noexcept :
+    replace_if_skipped(replacement_fail_t) noexcept :
         store_(detail::replace_mode::fail)
     {}
 
-    explicit replace_if_skipped(replacement_ignore_t) noexcept :
+    replace_if_skipped(replacement_ignore_t) noexcept :
         store_(detail::replace_mode::ignore)
     {}
 

--- a/include/commata/field_scanners.hpp
+++ b/include/commata/field_scanners.hpp
@@ -31,7 +31,7 @@ public:
 
 struct fail_if_skipped
 {
-    fail_if_skipped(replacement_fail_t = replacement_fail)
+    explicit fail_if_skipped(replacement_fail_t = replacement_fail)
     {}
 
     template <class T>
@@ -45,7 +45,7 @@ struct fail_if_skipped
 
 struct ignore_if_skipped
 {
-    ignore_if_skipped(replacement_ignore_t = replacement_ignore)
+    explicit ignore_if_skipped(replacement_ignore_t = replacement_ignore)
     {}
 
     std::nullopt_t operator()() const
@@ -236,6 +236,20 @@ public:
     template <class U = T,
         std::enable_if_t<
             std::is_constructible_v<T, U>
+         && !std::is_convertible_v<U&&, T>
+         && !(std::is_base_of_v<replace_if_skipped, std::decay_t<U>>
+           || std::is_base_of_v<replacement_fail_t, std::decay_t<U>>
+           || std::is_base_of_v<replacement_ignore_t, std::decay_t<U>>)>*
+                = nullptr>
+    explicit replace_if_skipped(U&& u = std::decay_t<U>())
+        noexcept(std::is_nothrow_constructible_v<T, U>) :
+        store_(generic_args_t(), std::forward<U>(u))
+    {}
+
+    template <class U = T,
+        std::enable_if_t<
+            std::is_constructible_v<T, U>
+         && std::is_convertible_v<U&&, T>
          && !(std::is_base_of_v<replace_if_skipped, std::decay_t<U>>
            || std::is_base_of_v<replacement_fail_t, std::decay_t<U>>
            || std::is_base_of_v<replacement_ignore_t, std::decay_t<U>>)>*
@@ -245,11 +259,11 @@ public:
         store_(generic_args_t(), std::forward<U>(u))
     {}
 
-    replace_if_skipped(replacement_fail_t) noexcept :
+    explicit replace_if_skipped(replacement_fail_t) noexcept :
         store_(detail::replace_mode::fail)
     {}
 
-    replace_if_skipped(replacement_ignore_t) noexcept :
+    explicit replace_if_skipped(replacement_ignore_t) noexcept :
         store_(detail::replace_mode::ignore)
     {}
 

--- a/include/commata/text_value_translation.hpp
+++ b/include/commata/text_value_translation.hpp
@@ -788,16 +788,24 @@ void swap(nontrivial_store<T, N>& left, nontrivial_store<T, N>& right)
     left.swap(right);
 }
 
+template <class A>
+constexpr bool is_replacement_tag_v =
+    std::is_base_of_v<replacement_fail_t, A>
+ || std::is_base_of_v<replacement_ignore_t, A>;
+
 template <class T, class A>
 constexpr bool is_acceptable_arg_v =
-    std::is_base_of_v<replacement_fail_t, std::decay_t<A>>
- || std::is_base_of_v<replacement_ignore_t, std::decay_t<A>>
+    is_replacement_tag_v<std::remove_reference_t<A>>
  || std::is_constructible_v<T, A>;
 
 template <class T, class A>
+constexpr bool is_implicitly_acceptable_arg_v =
+    is_replacement_tag_v<std::remove_reference_t<A>>
+ || std::is_convertible_v<A, T>;
+
+template <class T, class A>
 constexpr bool is_nothrow_arg_v =
-    std::is_base_of_v<replacement_fail_t, std::decay_t<A>>
- || std::is_base_of_v<replacement_ignore_t, std::decay_t<A>>
+    is_replacement_tag_v<std::remove_reference_t<A>>
  || std::is_nothrow_constructible_v<T, A>;
 
 template <class T, unsigned N>
@@ -836,15 +844,16 @@ template <class T>
 struct base<T, 3> : base_base<T, 3>
 {
     template <class All = T,
-        std::enable_if_t<!std::is_convertible_v<const All&, T>
-                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
+        std::enable_if_t<
+            is_acceptable_arg_v<T, const All&>
+         && !is_implicitly_acceptable_arg_v<T, const All&>>* = nullptr>
     explicit base(const All& for_all = All()) :
         base(for_all, for_all, for_all)
     {}
 
     template <class All = T,
-        std::enable_if_t<std::is_convertible_v<const All&, T>
-                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
+        std::enable_if_t<
+            is_implicitly_acceptable_arg_v<T, const All&>>* = nullptr>
     base(const All& for_all = All()) :
         base(for_all, for_all, for_all)
     {}
@@ -883,15 +892,16 @@ template <class T>
 struct base<T, 4> : base_base<T, 4>
 {
     template <class All = T,
-        std::enable_if_t<!std::is_convertible_v<const All&, T>
-                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
+        std::enable_if_t<
+            is_acceptable_arg_v<T, const All&>
+         && !is_implicitly_acceptable_arg_v<T, const All&>>* = nullptr>
     explicit base(const All& for_all = All()) :
         base(for_all, for_all, for_all, for_all)
     {}
 
     template <class All = T,
-        std::enable_if_t<std::is_convertible_v<const All&, T>
-                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
+        std::enable_if_t<
+            is_implicitly_acceptable_arg_v<T, const All&>>* = nullptr>
     base(const All& for_all = All()) :
         base(for_all, for_all, for_all, for_all)
     {}
@@ -947,15 +957,16 @@ template <class T>
 struct base<T, 5> : base_base<T, 5>
 {
     template <class All = T,
-        std::enable_if_t<!std::is_convertible_v<const All&, T>
-                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
+        std::enable_if_t<
+            is_acceptable_arg_v<T, const All&>
+         && !is_implicitly_acceptable_arg_v<T, const All&>>* = nullptr>
     explicit base(const All& for_all = All()) :
         base(for_all, for_all, for_all, for_all, for_all)
     {}
 
     template <class All = T,
-        std::enable_if_t<std::is_convertible_v<const All&, T>
-                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
+        std::enable_if_t<
+            is_implicitly_acceptable_arg_v<T, const All&>>* = nullptr>
     base(const All& for_all = All()) :
         base(for_all, for_all, for_all, for_all, for_all)
     {}

--- a/include/commata/text_value_translation.hpp
+++ b/include/commata/text_value_translation.hpp
@@ -379,7 +379,7 @@ struct converter<T, std::void_t<typename numeric_type_traits<T>::raw_type>> :
 
 struct fail_if_conversion_failed
 {
-    explicit fail_if_conversion_failed(replacement_fail_t = replacement_fail)
+    fail_if_conversion_failed(replacement_fail_t = replacement_fail)
     {}
 
     template <class T, class Ch>
@@ -479,8 +479,7 @@ private:
 
 struct ignore_if_conversion_failed
 {
-    explicit ignore_if_conversion_failed(
-        replacement_ignore_t = replacement_ignore)
+    ignore_if_conversion_failed(replacement_ignore_t = replacement_ignore)
     {}
 
     std::nullopt_t operator()(invalid_format_t) const

--- a/include/commata/text_value_translation.hpp
+++ b/include/commata/text_value_translation.hpp
@@ -379,7 +379,7 @@ struct converter<T, std::void_t<typename numeric_type_traits<T>::raw_type>> :
 
 struct fail_if_conversion_failed
 {
-    fail_if_conversion_failed(replacement_fail_t = replacement_fail)
+    explicit fail_if_conversion_failed(replacement_fail_t = replacement_fail)
     {}
 
     template <class T, class Ch>
@@ -479,7 +479,8 @@ private:
 
 struct ignore_if_conversion_failed
 {
-    ignore_if_conversion_failed(replacement_ignore_t = replacement_ignore)
+    explicit ignore_if_conversion_failed(
+        replacement_ignore_t = replacement_ignore)
     {}
 
     std::nullopt_t operator()(invalid_format_t) const
@@ -836,7 +837,15 @@ template <class T>
 struct base<T, 3> : base_base<T, 3>
 {
     template <class All = T,
-        std::enable_if_t<is_acceptable_arg_v<T, const All&>>* = nullptr>
+        std::enable_if_t<!std::is_convertible_v<const All&, T>
+                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
+    explicit base(const All& for_all = All()) :
+        base(for_all, for_all, for_all)
+    {}
+
+    template <class All = T,
+        std::enable_if_t<std::is_convertible_v<const All&, T>
+                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
     base(const All& for_all = All()) :
         base(for_all, for_all, for_all)
     {}
@@ -875,7 +884,15 @@ template <class T>
 struct base<T, 4> : base_base<T, 4>
 {
     template <class All = T,
-        std::enable_if_t<is_acceptable_arg_v<T, const All&>>* = nullptr>
+        std::enable_if_t<!std::is_convertible_v<const All&, T>
+                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
+    explicit base(const All& for_all = All()) :
+        base(for_all, for_all, for_all, for_all)
+    {}
+
+    template <class All = T,
+        std::enable_if_t<std::is_convertible_v<const All&, T>
+                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
     base(const All& for_all = All()) :
         base(for_all, for_all, for_all, for_all)
     {}
@@ -931,7 +948,15 @@ template <class T>
 struct base<T, 5> : base_base<T, 5>
 {
     template <class All = T,
-        std::enable_if_t<is_acceptable_arg_v<T, const All&>>* = nullptr>
+        std::enable_if_t<!std::is_convertible_v<const All&, T>
+                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
+    explicit base(const All& for_all = All()) :
+        base(for_all, for_all, for_all, for_all, for_all)
+    {}
+
+    template <class All = T,
+        std::enable_if_t<std::is_convertible_v<const All&, T>
+                      && is_acceptable_arg_v<T, const All&>>* = nullptr>
     base(const All& for_all = All()) :
         base(for_all, for_all, for_all, for_all, for_all)
     {}

--- a/src_test/TestRecordTranslator.cpp
+++ b/src_test/TestRecordTranslator.cpp
@@ -221,10 +221,6 @@ static_assert(std::is_same_v<
         replace_if_skipped<std::string>>,
     decltype(string_field_translator_factory("..."s))>);
 static_assert(std::is_same_v<
-    string_field_translator_factory<std::string,
-        replace_if_skipped<std::string>>,
-    decltype(string_field_translator_factory("..."sv))>);
-static_assert(std::is_same_v<
     string_field_translator_factory<std::wstring,
         replace_if_skipped<std::wstring>>,
     decltype(string_field_translator_factory(L"..."))>);

--- a/src_test/TestTableScanner.cpp
+++ b/src_test/TestTableScanner.cpp
@@ -1463,7 +1463,14 @@ struct B
 struct D : B
 {};
 
+struct E
+{
+    explicit E(const B&)
+    {}
+};
+
 static_assert(std::is_convertible_v<D, replace_if_skipped<B>>);
+static_assert(!std::is_convertible_v<B, replace_if_skipped<E>>);
 
 } // end unnamed
 

--- a/src_test/TestTextValueTranslation.cpp
+++ b/src_test/TestTextValueTranslation.cpp
@@ -170,7 +170,14 @@ struct B
 struct D : B
 {};
 
+struct E
+{
+    explicit E(const B&)
+    {}
+};
+
 static_assert(std::is_convertible_v<D, replace_if_conversion_failed<B>>);
+static_assert(!std::is_convertible_v<B, replace_if_conversion_failed<E>>);
 
 } // end unnamed
 

--- a/src_test/TestTextValueTranslation.cpp
+++ b/src_test/TestTextValueTranslation.cpp
@@ -179,6 +179,15 @@ struct E
 static_assert(std::is_convertible_v<D, replace_if_conversion_failed<B>>);
 static_assert(!std::is_convertible_v<B, replace_if_conversion_failed<E>>);
 
+static_assert(
+    !std::is_convertible_v<
+        std::string_view,
+        replace_if_conversion_failed<std::string>>);
+static_assert(
+    std::is_constructible_v<
+        replace_if_conversion_failed<std::string>,
+        std::string_view>);
+
 } // end unnamed
 
 TYPED_TEST_SUITE(TestReplaceIfConversionFailed, ReplacedTypes, );

--- a/src_test/TestTextValueTranslation.cpp
+++ b/src_test/TestTextValueTranslation.cpp
@@ -180,6 +180,10 @@ static_assert(std::is_convertible_v<D, replace_if_conversion_failed<B>>);
 static_assert(!std::is_convertible_v<B, replace_if_conversion_failed<E>>);
 
 static_assert(
+    std::is_convertible_v<
+        replacement_fail_t,
+        replace_if_conversion_failed<std::string>>);
+static_assert(
     !std::is_convertible_v<
         std::string_view,
         replace_if_conversion_failed<std::string>>);


### PR DESCRIPTION
With #104, one-parameter ctors of `replace_if_skipped` and `replace_if_conversion_failed` became not `explicit` at all. But now it seems too loose. Surely we would not like to write:

```c++
std::string_view v = "skipped";
string_field_translator_factory<std::string, replace_if_skipped<std::string>>
  f(replace_if_skipped<std::string>(v));
```

but we can and should write instead:

```c++
std::string_view v = "skipped";
string_field_translator_factory<std::string, replace_if_skipped<std::string>>
  f(std::string(v));
```

and should regard codes below as 'too loose':

```c++
std::string_view v = "skipped";
string_field_translator_factory<std::string, replace_if_skipped<std::string>>
  f(v);
```

From this point of view, explicitness of these ctors should be decided respectfully to the inconvertibleness from the type of the argument to `T`.

But we should allow conversions from tags such as `replacement_fail_t` and `replacement_ignore_t` to `fail_if`, `ignore_if` and `replace_if` types.

This pull request is to do that.