### PR TITLE
Add a space after every equals sign

### DIFF
--- a/include/commata/char_input.hpp
+++ b/include/commata/char_input.hpp
@@ -79,7 +79,7 @@ public:
     {}
 
     streambuf_input(const streambuf_input& other) = default;
-    streambuf_input& operator=(const streambuf_input&) =default;
+    streambuf_input& operator=(const streambuf_input&) = default;
 
     size_type operator()(Ch* out, size_type n)
     {
@@ -162,7 +162,7 @@ public:
     {}
 
     istream_input(const istream_input& other) = default;
-    istream_input& operator=(const istream_input&) =default;
+    istream_input& operator=(const istream_input&) = default;
 
     size_type operator()(Ch* out, size_type n)
     {

--- a/src_test/TestParseCsv.cpp
+++ b/src_test/TestParseCsv.cpp
@@ -431,14 +431,14 @@ public:
 TEST_P(TestParseCsvBasics, ParsePointGood)
 {
     const auto l = "ABCD,EFGH,\"IJKL\"\r\n"sv;
-    const auto r =make_csv_source(l)(aborting_handler())();
+    const auto r = make_csv_source(l)(aborting_handler())();
     ASSERT_EQ(l.size(), get_parse_point(r));
 }
 
 TEST_P(TestParseCsvBasics, ParsePointAbortStartRecord)
 {
     const auto l = "ABCD,EFGH,\"ABORT start_record\"\r\n"sv;
-    const auto r =make_csv_source(std::string(l) + "\"IJKL\"")
+    const auto r = make_csv_source(std::string(l) + "\"IJKL\"")
         (aborting_handler())();
     ASSERT_EQ(l.size(), get_parse_point(r));
 }
@@ -446,7 +446,7 @@ TEST_P(TestParseCsvBasics, ParsePointAbortStartRecord)
 TEST_P(TestParseCsvBasics, ParsePointAbortEndRecord)
 {
     const auto l = "ABCD,EFGH,\"ABORT end_record\""sv;
-    const auto r =make_csv_source(std::string(l) + "\r\r\n")
+    const auto r = make_csv_source(std::string(l) + "\r\r\n")
         (aborting_handler())();
     ASSERT_EQ(l.size(), get_parse_point(r));
 }
@@ -454,7 +454,7 @@ TEST_P(TestParseCsvBasics, ParsePointAbortEndRecord)
 TEST_P(TestParseCsvBasics, ParsePointAbortEmptyPhysicalLine)
 {
     const auto l = "ABCD,EFGH,\"ABORT empty_physical_line\"\n"sv;
-    const auto r =make_csv_source(std::string(l) + "\nXYZ\n")
+    const auto r = make_csv_source(std::string(l) + "\nXYZ\n")
         (aborting_handler())();
     ASSERT_EQ(l.size(), get_parse_point(r));
 }
@@ -462,7 +462,7 @@ TEST_P(TestParseCsvBasics, ParsePointAbortEmptyPhysicalLine)
 TEST_P(TestParseCsvBasics, ParsePointAbortFinalize)
 {
     const auto l = "ABCD,EFGH,\"ABORT \"\"finalize\"\"\""sv;
-    const auto r =make_csv_source(std::string(l) + "\r\n")
+    const auto r = make_csv_source(std::string(l) + "\r\n")
         (aborting_handler())();
     ASSERT_EQ(l.size(), get_parse_point(r));
 }

--- a/src_test/TestStoredTable.cpp
+++ b/src_test/TestStoredTable.cpp
@@ -263,7 +263,7 @@ TYPED_TEST(TestStoredValueNoModification, Strings)
 {
     using char_t = TypeParam;
     using decayed_char_t = std::remove_const_t<char_t>;
-    using string_t =std::basic_string<decayed_char_t>;
+    using string_t = std::basic_string<decayed_char_t>;
     using value_t = basic_stored_value<char_t>;
 
     const auto str0 = char_helper<decayed_char_t>::str0;
@@ -1178,7 +1178,7 @@ struct TestStoredTableMerge : BaseTest
 
 namespace {
 
-using ContentLRs =testing::Types<
+using ContentLRs = testing::Types<
     std::pair<
         std::vector<std::vector<stored_value>>,
         std::vector<std::vector<stored_value>>>,


### PR DESCRIPTION
Literally. Just an cosmetic issue.