### PR TITLE
Fix the parameter type of release_buffer of wrapper handlers

### DIFF
--- a/docs/CommataSpecification.xml
+++ b/docs/CommataSpecification.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="Commata.xsl"?>
 <document>
 <title>Specification of Commata, which is just another C++17 CSV parser</title>
-<signature>2026-06-23 (UTC)</signature>
+<signature>2026-06-26 (UTC)</signature>
 
 <section id="introduction">
   <name>Introduction</name>
@@ -1065,7 +1065,7 @@ namespace commata {
 
     <c>// <n><xref id="reference_handler.inv"/>, invocation:</n></c>
     <nc>see below</nc> get_buffer();
-    <nc>see below</nc> release_buffer(char_type* buffer);
+    <nc>see below</nc> release_buffer(std::remove_const_t&lt;char_type>* buffer);
     template &lt;class Ch> <nc>see below</nc> start_buffer(Ch* buffer_begin, Ch* buffer_end);
     template &lt;class Ch> <nc>see below</nc> end_buffer(Ch* buffer_end);
     template &lt;class Ch> <nc>see below</nc> empty_physical_line(Ch* where);
@@ -1148,10 +1148,12 @@ handler_type&amp; base() const noexcept;
 
         <code-item>
           <code>
-<nc>see below</nc> release_buffer(char_type* buffer);
+<nc>see below</nc> release_buffer(std::remove_const_t&lt;char_type>* buffer);
           </code>
           <effects>Equivalent to: <c>return base().release_buffer(buffer);</c></effects>
-          <remark>This member function shall not be declared unless <c>std::declval&lt;Handler&amp;>().release_buffer(buffer)</c> is well-formed when treated as an unevaluated operand.</remark>
+          <remark>Let <c>E</c> be an expression <c>std::declval&lt;Handler&amp;>().release_buffer(std::declval&lt;std::remove_const_t&lt;char_type*>>())</c>.
+                  The return type is <c>decltype(E)</c>.
+                  This member function shall not be declared unless <c>E</c> is well-formed when treated as an unevaluated operand.</remark>
         </code-item>
 
         <code-item>
@@ -1310,7 +1312,7 @@ namespace commata {
 
     <c>// <n><xref id="empty_physical_line_aware_handler.inv"/>, invocation:</n></c>
     <nc>see below</nc> get_buffer();
-    <nc>see below</nc> release_buffer(char_type* buffer);
+    <nc>see below</nc> release_buffer(std::remove_const_t&lt;char_type>* buffer);
     template &lt;class Ch> <nc>see below</nc> start_buffer(Ch* buffer_begin, Ch* buffer_end);
     template &lt;class Ch> <nc>see below</nc> end_buffer(Ch* buffer_end);
     template &lt;class Ch> <nc>see below</nc> empty_physical_line(Ch* where);
@@ -1444,10 +1446,12 @@ const handler_type&amp; base() const noexcept;
 
         <code-item>
           <code>
-<nc>see below</nc> release_buffer(char_type* buffer);
+<nc>see below</nc> release_buffer(std::remove_const_t&lt;char_type>* buffer);
           </code>
           <effects>Equivalent to: <c>return base().release_buffer(buffer);</c></effects>
-          <remark>This member function shall not be declared unless <c>std::declval&lt;Handler&amp;>().release_buffer(buffer)</c> is well-formed when treated as an unevaluated operand.</remark>
+          <remark>Let <c>E</c> be an expression <c>std::declval&lt;Handler&amp;>().release_buffer(std::declval&lt;std::remove_const_t&lt;char_type*>>())</c>.
+                  The return type is <c>decltype(E)</c>.
+                  This member function shall not be declared unless <c>E</c> is well-formed when treated as an unevaluated operand.</remark>
         </code-item>
 
         <code-item>

--- a/include/commata/detail/handler_decorator.hpp
+++ b/include/commata/detail/handler_decorator.hpp
@@ -147,7 +147,8 @@ template <class Handler, class D>
 struct release_buffer_t<Handler, D,
     std::enable_if_t<has_release_buffer_v<Handler>>>
 {
-    auto release_buffer(typename Handler::char_type* buffer)
+    auto release_buffer(
+        std::remove_const_t<typename Handler::char_type>* buffer)
      -> decltype(std::declval<Handler&>().release_buffer(buffer))
     {
         return static_cast<D*>(this)->base().release_buffer(buffer);


### PR DESCRIPTION
The parameter type of `release_buffer` of `handler_decorator`, and thus of `reference_handler` or `empty_physical_line_aware_handler`, has been wrongly possibly const-qualified.

An invocation to `release_buffer` of a `TableHandler` object is expected to re-register the buffer into its empty-list for reuse or deallocate the buffer with its allocator. So the parameter type should not be const-qualified. In addition, the `TableHandler` requirements already mandate this non-const-ness.